### PR TITLE
Can now make flash messages sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [Statistics for `ember-cli-flash`](http://www.npm-stats.com/~packages/ember-cli-flash)
 
-This `ember-cli` addon adds a simple flash message service to your app. It's injected into all Controllers, Routes, Views and Components by default. It can also be lazily injected.
+This `ember-cli` addon adds a simple flash message service to your app. It's injected into all `Controllers`, `Routes`, `Views` and `Components` by default. It can also be lazily injected.
 
 ## Installation
 You can install either with `npm`:
@@ -21,22 +21,21 @@ ember install:addon ember-cli-flash
 ## Usage
 Usage is very simple. From within a `Controller`, `Route`, `View` or `Component`:
 
-### API
-#### Convenience methods (Bootstrap / Foundation alerts)
+### Convenience methods (Bootstrap / Foundation alerts)
 You can quickly add flash messages using:
 
-##### Bootstrap
+#### Bootstrap
 - `.success`
 - `.warning`
 - `.info`
 - `.danger`
 
-##### Foundation
+#### Foundation
 - `.success`
 - `.warning`
 - `.info`
 - `.alert`
-- `.secondary` 
+- `.secondary`
 
 These will add the appropriate classes to the flash message component for styling in Bootstrap or Foundation. For example:
 
@@ -46,39 +45,63 @@ These will add the appropriate classes to the flash message component for stylin
 Ember.get(this, 'flashes').success('Success!');
 ```
 
-You can also pass in options for `timeout` and `priority`. The best practise is to use priority values in multiples of `100` (`100` being the lowest priority):
+### Custom messages
+If the convenience methods don't fit your needs, you can add custom messages with `add`:
 
 ```javascript
-Ember.get(this, 'flashes').warning('Something went wrong', {
-  priority : 1000
-});
-
-Ember.get(this, 'flashes').success('Successfully signed in', {
-  timeout  : 500,
-  priority : 200
-});
-```
-
-The `warning` message will appear on top of the `success` message. Messages with the highest `priority` values will appear at the top of the queue.
-
-#### Custom messages
-If the convenience methods don't fit your needs, you can add custom messages:
-
-```javascript
-Ember.get(this, 'flashes').addMessage('You won!', {
-  type    : 'congratulations',
-  timeout : 3000
-});
-
 Ember.get(this, 'flashes').add({
-  message  : 'Custom message'
-  type     : 'customType',
-  timeout  : 2000,
-  priority : 500
+  message: 'Custom message'
 });
 ```
 
-#### Registering new types
+### Options
+You can also pass in options:
+
+```javascript
+Ember.get(this, 'flashes').add({
+  message  : 'I like alpacas',
+  type     : 'alpaca'
+  timeout  : 500,
+  priority : 200,
+  sticky   : true
+});
+
+Ember.get(this, 'flashes').success('This is amazing', {
+  timeout  : 100,
+  priority : 100,
+  sticky   : false
+});
+```
+
+- `message: string`
+  
+  Required. The message that the flash message displays.
+
+- `type?: string`
+  
+  Default: `info`
+
+  This is mainly used for styling. The flash message's `type` is set as a class name on the rendered component, together with a prefix. The rendered class name depends on the message type that was passed into the component.
+
+- `timeout?: number`
+
+  Default: `3000`
+
+  Number of milliseconds before a flash message is automatically removed.
+
+- `priority?: number`
+  
+  Default: `100`
+
+  Higher priority messages appear before low priority messages. The best practise is to use priority values in multiples of `100` (`100` being the lowest priority).
+
+- `sticky?: boolean`
+  
+  Default: `false`
+
+  By default, flash messages disappear after a certain amount of time. To disable this and make flash messages permanent (they can still be dismissed by click), set `sticky` to true.
+
+### Registering new types
 If you find yourself creating many custom messages with the same custom type, you can register it with the service and use that method instead.
 
 ```javascript
@@ -86,7 +109,7 @@ Ember.get(this, 'flashes').registerType('birthday');
 Ember.get(this, 'flashes').birthday("Hey shawty, it's your birthday");
 ```
 
-#### Clearing all messages on screen
+### Clearing all messages on screen
 It's best practise to use flash messages sparingly, only when you need to notify the user of something. If you're sending too many messages, and need a way for your users to clear all messages from screen, you can use this method:
 
 ```javascript
@@ -94,7 +117,7 @@ Ember.get(this, 'flashes').clearMessages(); // clears all visible flash messages
 ```
 
 ### Lazy service injection
-If you're using Ember `1.10.0` or higher, you can also inject the service manually:
+If you're using Ember `1.10.0` or higher, you can also inject the service manually on any `Ember.Object` registered in the container:
 
 ```javascript
 flashes: Ember.inject.service('flash-messages')

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { computed, get, on } = Ember;
+const { computed, getWithDefault } = Ember;
 
 export default Ember.Component.extend({
   classNames        : [ 'flashMessage' ],
@@ -8,9 +8,9 @@ export default Ember.Component.extend({
   messageStyle      : 'bootstrap',
 
   alertType: computed('flash.type', function() {
-    const flashType    = get(this, 'flash.type');
-    const messageStyle = get(this, 'messageStyle');
-    var prefix         = 'alert alert-';
+    const flashType    = getWithDefault(this, 'flash.type', '');
+    const messageStyle = getWithDefault(this, 'messageStyle', '');
+    let prefix         = 'alert alert-';
 
     if (messageStyle === 'foundation') {
       prefix = 'alert-box ';
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
   }),
 
   flashType: computed('flash.type', function() {
-    const flashType = get(this, 'flash.type');
+    const flashType = getWithDefault(this, 'flash.type', '');
 
     return flashType.classify();
   }),
@@ -29,13 +29,12 @@ export default Ember.Component.extend({
     this._destroyFlashMessage();
   },
 
-  //private
-  _destroyOnTeardown: on('willDestroyElement', function() {
+  willDestroy() {
     this._destroyFlashMessage();
-  }),
+  },
 
   _destroyFlashMessage() {
-    const flash = get(this, 'flash');
+    const flash = getWithDefault(this, 'flash', false);
 
     if (flash) {
       flash.destroyMessage();

--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -25,7 +25,6 @@ export default Ember.Object.extend({
   },
 
   willDestroy() {
-    this._super();
     const timer = get(this, 'timer');
 
     if (timer) {
@@ -36,6 +35,8 @@ export default Ember.Object.extend({
 
   // private
   _destroyLater: on('init', function() {
+    if (get(this, 'sticky')) { return; }
+
     const defaultTimeout = get(this, 'defaultTimeout');
     const timeout        = getWithDefault(this, 'timeout', defaultTimeout);
     const destroyTimer   = run.later(this, '_destroyMessage', timeout);

--- a/addon/services/flash-messages-service.js
+++ b/addon/services/flash-messages-service.js
@@ -6,8 +6,9 @@ const { computed, get, getWithDefault, A: emberArray, on } = Ember;
 export default Ember.Service.extend({
   queue           : emberArray([]),
   isEmpty         : computed.equal('queue.length', 0),
-  defaultTimeout  : 2000,
+  defaultTimeout  : 3000,
   defaultPriority : 100,
+  defaultSticky   : false,
   defaultTypes    : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ],
   defaultType     : 'info',
 
@@ -28,18 +29,22 @@ export default Ember.Service.extend({
         message  : message,
         type     : type,
         timeout  : options.timeout,
-        priority : options.priority
+        priority : options.priority,
+        sticky   : options.sticky
       });
     });
   },
 
   // custom
   addMessage(message, options={}) {
+    Ember.deprecate('[ember-cli-flash] `addMessage() will be deprecated in 1.0.0. Please use `add()` instead.`');
+
     return this._addToQueue({
       message  : message,
       type     : options.type,
       timeout  : options.timeout,
-      priority : options.priority
+      priority : options.priority,
+      sticky   : options.sticky
     });
   },
 
@@ -48,7 +53,8 @@ export default Ember.Service.extend({
       message  : options.message,
       type     : options.type,
       timeout  : options.timeout,
-      priority : options.priority
+      priority : options.priority,
+      sticky   : options.sticky
     });
   },
 
@@ -74,14 +80,16 @@ export default Ember.Service.extend({
     const timeout  = (options.timeout  === undefined) ? get(this, 'defaultTimeout')  : options.timeout;
     const type     = (options.type     === undefined) ? get(this, 'defaultType')     : options.type;
     const priority = (options.priority === undefined) ? get(this, 'defaultPriority') : options.priority;
+    const sticky   = (options.sticky   === undefined) ? get(this, 'defaultSticky')   : options.sticky;
     const service  = this;
 
     return FlashMessage.create({
+      flashService : service,
       message      : options.message,
       type         : type,
       timeout      : timeout,
       priority     : priority,
-      flashService : service
+      sticky       : sticky
     });
   },
 

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -6,6 +6,7 @@ import {
 import startApp from '../helpers/start-app';
 
 var application;
+const { run } = Ember;
 
 module('Acceptance: Integration', {
   beforeEach() {
@@ -37,4 +38,16 @@ test('high priority messages are rendered on top', function(assert) {
   assert.ok(find('.alert'));
   assert.equal(find('.alert h6').first().text(), 'warning');
   assert.equal(find('.alert p').first().text(), 'It is going to rain tomorrow');
+});
+
+test('sticky messages are not removed automatically', function(assert) {
+  assert.expect(4);
+  visit('/');
+
+  andThen(() => {
+    assert.ok(find('.alert.alert-danger'));
+    assert.equal(find('.alert').length, 1);
+    assert.equal(find('.alert.alert-danger h6').text(), 'danger');
+    assert.equal(find('.alert.alert-danger p').text(), 'You went offline');
+  });
 });

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -15,5 +15,7 @@ export default Ember.Route.extend({
       timeout  : 50,
       priority : 1000
     });
+
+    flashes.danger('You went offline', { sticky: true });
   }
 });

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import Ember from 'ember';
 import FlashMessage from 'ember-cli-flash/flash/object';
 
-var testTimerDuration = 500;
+var testTimerDuration = 50;
 var { run }           = Ember;
 var flash             = null;
 var SANDBOX           = {};
@@ -39,6 +39,24 @@ test('#_destroyLater destroys the message after the timer has elapsed', function
   }, testTimerDuration * 2);
 });
 
+test('#_destroyLater does not destroy the message if it is sticky', function(assert) {
+  const done = assert.async();
+  assert.expect(1);
+
+  const stickyFlash = FlashMessage.create({
+    type    : 'test',
+    message : 'Cool story brah',
+    timeout : testTimerDuration,
+    service : {},
+    sticky  : true
+  });
+
+  run.later(() => {
+    assert.equal(stickyFlash.get('isDestroyed'), false);
+    done();
+  }, testTimerDuration);
+});
+
 test('#destroyMessage deletes the message and timer', function(assert) {
   assert.expect(2);
 
@@ -49,4 +67,3 @@ test('#destroyMessage deletes the message and timer', function(assert) {
   assert.equal(flash.get('isDestroyed'), true);
   assert.equal(flash.get('timer'), null);
 });
-


### PR DESCRIPTION
- added deprecation warning for `addMessage`
- reduced testTimerDuration
- added test for sticky messages
- added integration test for sticky messages
- fixed a bug where sometimes flash messages would not be removed
- can now add sticky messages
- updated readme

Closes #12 