### PR TITLE
[WIP] Add initial theme option to the app config

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -5,11 +5,11 @@ const { computed, getWithDefault } = Ember;
 export default Ember.Component.extend({
   classNames        : [ 'flashMessage' ],
   classNameBindings : [ 'alertType' ],
-  messageStyle      : 'bootstrap',
+  messageStyle      : undefined,
 
   alertType: computed('flash.type', function() {
     const flashType    = getWithDefault(this, 'flash.type', '');
-    const messageStyle = getWithDefault(this, 'messageStyle', '');
+    const messageStyle = getWithDefault(this, 'messageStyle', Ember.ENV.flashTheme || 'bootstrap');
     let prefix         = 'alert alert-';
 
     if (messageStyle === 'foundation') {

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -3,6 +3,7 @@ import {
   test
 } from 'ember-qunit';
 import FlashMessage from 'ember-cli-flash/flash/object';
+import Ember from 'ember';
 
 var flash;
 
@@ -18,6 +19,7 @@ moduleForComponent('flash-message', 'FlashMessageComponent', {
 
   afterEach() {
     flash = null;
+    Ember.ENV.flashTheme = null;
   }
 });
 
@@ -41,6 +43,28 @@ test('#alertType returns the right type', function(assert) {
 
   this.render();
   assert.equal(component.get('alertType'), 'alert alert-test');
+});
+
+test('#alertType allows the messageStyle to be set', function(assert) {
+  assert.expect(1);
+
+  const component = this.subject();
+  component.set('messageStyle', 'foundation');
+  component.set('flash', flash);
+
+  this.render();
+  assert.equal(component.get('alertType'), 'alert-box test');
+});
+
+test('#alertType defaults to the config theme when not declared', function(assert) {
+  assert.expect(1);
+
+  const component = this.subject();
+  Ember.ENV.flashTheme = 'foundation';
+  component.set('flash', flash);
+
+  this.render();
+  assert.equal(component.get('alertType'), 'alert-box test');
 });
 
 test('#flashType returns the right classified alert type', function(assert) {


### PR DESCRIPTION
Firstly, thanks for an awesome addon.

Related to #10 

I'm not quite sure what options you want to expose in the
application config for flash message, so I've currently just
exposed a `flashTheme` config option. This is what the `alertType`
will use to infer the class prefix. One can still explicitly
set the `messageType` in the component declaratively, I've added
a test to verify that as well.

Is this along the lines of what you were thinking? What else
would you like to see here?