### PR TITLE
[WIP] Allow global service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ Ember.get(this, 'flashes').success('This is amazing', {
 
   To show a progress bar in the flash message, set this to true.
 
+### Global options
+In `config/environment`, you can set global configuration options in the `flashMessageDefaults` object:
+
+```js
+module.exports = function(environment) {
+  var ENV = {
+    // ...
+
+    flashMessageDefaults: {
+      timeout      : 10000,
+      priority     : 200,
+      sticky       : true,
+      showProgress : true,
+      type         : 'foobar',
+      types        : [ 'warning', 'notice', 'foobar' ]
+    },
+
+    // ...
+  }
+}
+```
+
+See the [options](#options) section for detailed option information.
+
 ### Registering new types
 If you find yourself creating many custom messages with the same custom type, you can register it with the service and use that method instead.
 

--- a/addon/services/flash-messages-service.js
+++ b/addon/services/flash-messages-service.js
@@ -5,6 +5,7 @@ const {
   computed,
   get: get,
   getWithDefault,
+  set,
   A: emberArray,
   on
 } = Ember;
@@ -12,14 +13,7 @@ const {
 export default Ember.Service.extend({
   queue               : emberArray([]),
   isEmpty             : computed.equal('queue.length', 0),
-
-  // refactor
-  defaultTimeout      : 3000,
-  defaultPriority     : 100,
-  defaultSticky       : false,
-  defaultShowProgress : false,
   defaultTypes        : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ],
-  defaultType         : 'info',
 
   arrangedQueue: computed.sort('queue', function(a, b) {
     if (a.priority < b.priority) {
@@ -96,6 +90,31 @@ export default Ember.Service.extend({
       showProgress : showProgress || get(this, 'defaultShowProgress')
     });
   },
+
+  _getDefaults() {
+    const serviceDefaults = {
+      timeout      : 3000,
+      priority     : 100,
+      sticky       : false,
+      showProgress : false,
+      type         : 'info'
+    };
+
+    var defaults = Ember.ENV.flashMessageDefaults || {};
+    Ember.merge(defaults, serviceDefaults);
+    return defaults;
+  },
+
+  _setDefaults: on('init', function() {
+    var defaults = this._getDefaults();
+
+    Object.keys(defaults).map((key) => {
+      const classifiedKey = key.classify();
+      const defaultKey    = `default${classifiedKey}`;
+
+      set(this, defaultKey, defaults[key]);
+    });
+  }),
 
   _registerTypes(types=[]) {
     types.forEach(type => this.registerType(type));

--- a/addon/services/flash-messages-service.js
+++ b/addon/services/flash-messages-service.js
@@ -13,7 +13,6 @@ const {
 export default Ember.Service.extend({
   queue               : emberArray([]),
   isEmpty             : computed.equal('queue.length', 0),
-  defaultTypes        : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ],
 
   arrangedQueue: computed.sort('queue', function(a, b) {
     if (a.priority < b.priority) {
@@ -97,7 +96,8 @@ export default Ember.Service.extend({
       priority     : 100,
       sticky       : false,
       showProgress : false,
-      type         : 'info'
+      type         : 'info',
+      types        : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ]
     };
 
     var defaults = Ember.ENV.flashMessageDefaults || {};
@@ -114,15 +114,12 @@ export default Ember.Service.extend({
 
       set(this, defaultKey, defaults[key]);
     });
+
+    const defaultTypes = getWithDefault(this, 'defaultTypes', []);
+    this._registerTypes(defaultTypes);
   }),
 
   _registerTypes(types=[]) {
     types.forEach(type => this.registerType(type));
-  },
-
-  _initTypes: on('init', function() {
-    const defaultTypes = getWithDefault(this, 'defaultTypes', []);
-
-    this._registerTypes(defaultTypes);
-  })
+  }
 });

--- a/index.js
+++ b/index.js
@@ -18,6 +18,21 @@ module.exports = {
     registry.add('js', plugin);
   },
 
+  config: function(environment /*, appConfig*/) {
+    var ENV = {
+      flashMessageDefaults: {
+        timeout      : 3000,
+        priority     : 100,
+        sticky       : false,
+        showProgress : false,
+        type         : 'info',
+        types        : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ]
+      }
+    }
+
+    return ENV;
+  },
+
   included: function(app) {
     this._super.included(app);
     app.import('vendor/flash-message/style.css');

--- a/tests/unit/services/flash-messages-service-test.js
+++ b/tests/unit/services/flash-messages-service-test.js
@@ -10,7 +10,8 @@ var flashMessageDefaults = {
   priority     : 200,
   sticky       : true,
   showProgress : true,
-  type         : 'foobar'
+  type         : 'foobar',
+  types        : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ]
 };
 
 module('FlashMessagesService', {

--- a/tests/unit/services/flash-messages-service-test.js
+++ b/tests/unit/services/flash-messages-service-test.js
@@ -5,6 +5,13 @@ import FlashMessagesService from 'ember-cli-flash/services/flash-messages-servic
 var service;
 var SANDBOX = {};
 var { run } = Ember;
+var flashMessageDefaults = {
+  timeout      : 10000,
+  priority     : 200,
+  sticky       : true,
+  showProgress : true,
+  type         : 'foobar'
+};
 
 module('FlashMessagesService', {
   beforeEach() {
@@ -154,5 +161,19 @@ test('#_initTypes registers default types on init', function(assert) {
 
     assert.ok(method);
     assert.equal(Ember.typeOf(method), 'function');
+  });
+});
+
+test('#_setDefaults sets the correct defaults for service properties', function(assert) {
+  Ember.ENV.flashMessageDefaults = flashMessageDefaults;
+  service = FlashMessagesService.create({});
+
+  const defaultOptions = Object.keys(flashMessageDefaults);
+  const expectLength   = defaultOptions.length;
+
+  assert.expect(expectLength);
+
+  defaultOptions.forEach(function(defaultOption) {
+    assert.equal(service.get(`default${defaultOption.classify()}`), flashMessageDefaults[defaultOption]);
   });
 });


### PR DESCRIPTION
Here's the first pass, as discussed.

__TODO:__
- [x] Implement the service configuration from the ENV.
- [x] Use the config hook to set defaults.
- [x] A few tests to ensure defaults are being loaded from the config.
- [x] Document it.

Closes #6, partially address #9.