### PR TITLE
Minor build/test tweaks.

### DIFF
--- a/app/templates/components/flash-message.hbs
+++ b/app/templates/components/flash-message.hbs
@@ -4,7 +4,7 @@
   {{flash.message}}
   {{#if showProgressBar}}
     <div class="alert-progress">
-      <div class="alert-progressBar" style="{{progressDuration}}"></div>
+      <div class="alert-progressBar" style={{progressDuration}}></div>
     </div>
   {{/if}}
 {{/if}}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.11.0",
-    "ember-data": "1.0.0-beta.16.1",
     "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,37 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'ember-1.11.1',
+      dependencies: {
+        "ember": "1.11.1"
+      }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        "ember": "components/ember#release"
+      },
+      resolutions: {
+        "ember": "release"
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        "ember": "components/ember#beta"
+      },
+      resolutions: {
+        "ember": "beta"
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        "ember": "components/ember#canary"
+      },
+      resolutions: {
+        "ember": "canary"
+      }
+    }
+  ]
+};

--- a/index.js
+++ b/index.js
@@ -3,43 +3,4 @@
 
 module.exports = {
   name: 'ember-cli-flash',
-
-  setupPreprocessorRegistry: function(type, registry) {
-    var options = getOptions(this.parent && this.parent.options && this.parent.options['babel']);
-
-    var plugin = {
-      name   : 'ember-cli-babel',
-      ext    : 'js',
-      toTree : function(tree) {
-        return require('broccoli-babel-transpiler')(tree, options);
-      }
-    };
-
-    registry.add('js', plugin);
-  }
 };
-
-// https://github.com/babel/ember-cli-babel/blob/master/index.js
-function getOptions(options) {
-  options = options || {};
-
-  // Ensure modules aren't compiled unless explicitly set to compile
-  options.blacklist = options.blacklist || ['es6.modules'];
-
-  if (options.compileModules === true) {
-    if (options.blacklist.indexOf('es6.modules') >= 0) {
-      options.blacklist.splice(options.blacklist.indexOf('es6.modules'), 1);
-    }
-
-    delete options.compileModules;
-  } else {
-    if (options.blacklist.indexOf('es6.modules') < 0) {
-      options.blacklist.push('es6.modules');
-    }
-  }
-
-  // Ember-CLI inserts its own 'use strict' directive
-  options.blacklist.push('useStrict');
-
-  return options;
-}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "author": "Lauren Tan",
   "license": "MIT",
   "dependencies": {
-    "broccoli-babel-transpiler": "^4.0.1",
-    "ember-cli-babel": "^4.0.0"
+    "ember-cli-babel": "^5.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test"
+    "test": "ember try:testall"
   },
   "repository": "https://github.com/poteto/ember-cli-flash",
   "engines": {
@@ -34,7 +34,8 @@
     "ember-data": "1.0.0-beta.16.1",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-sinon": "0.0.3"
+    "ember-sinon": "0.0.3",
+    "ember-try": "0.0.3"
   },
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.16.1",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "ember-sinon": "0.0.3",


### PR DESCRIPTION
* Remove ember-data from build.  This library does not use ember-data, and occasionally having ember-data in the build causes test failures (ember-data 1.0.0-beta.16.1 does not work with Ember canary at this point).
* Test across many versions of Ember.
* Use ember-cli-babel instead of custom preprocessor.
* Fix style warning on 1.12.0-beta.1+.