### PR TITLE
Refactoring

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -3,10 +3,7 @@ import Ember from 'ember';
 const {
   computed,
   getWithDefault,
-  get: get,
-  set: set,
-  on,
-  run
+  get: get
 } = Ember;
 
 const { escapeExpression } = Ember.Handlebars.Utils;
@@ -14,8 +11,9 @@ const { SafeString }       = Ember.Handlebars;
 
 export default Ember.Component.extend({
   classNameBindings : [ 'alertType', 'active' ],
+  active            : true,
   messageStyle      : 'bootstrap',
-  showProgressBar   : computed.alias('flash.showProgress'),
+  showProgressBar   : computed.readOnly('flash.showProgress'),
 
   alertType: computed('flash.type', function() {
     const flashType    = getWithDefault(this, 'flash.type', '');
@@ -27,14 +25,14 @@ export default Ember.Component.extend({
     }
 
     return `${prefix}${flashType}`;
-  }),
+  }).readOnly(),
 
   flashType: computed('flash.type', function() {
     const classify  = Ember.String.classify;
     const flashType = getWithDefault(this, 'flash.type', '');
 
     return classify(flashType);
-  }),
+  }).readOnly(),
 
   progressDuration: computed('flash.showProgress', function() {
     if (!get(this, 'flash.showProgress')) {
@@ -44,13 +42,14 @@ export default Ember.Component.extend({
     const duration   = getWithDefault(this, 'flash.timeout', 0);
     const escapedCSS = escapeExpression(`transition-duration: ${duration}ms`);
     return new SafeString(escapedCSS);
-  }),
+  }).readOnly(),
 
   click() {
     this._destroyFlashMessage();
   },
 
   willDestroy() {
+    this._super();
     this._destroyFlashMessage();
   },
 
@@ -61,11 +60,5 @@ export default Ember.Component.extend({
     if (flash) {
       flash.destroyMessage();
     }
-  },
-
-  _activeAfterRender: on('didInsertElement', function() {
-    run.scheduleOnce('afterRender', this, () => {
-      set(this, 'active', true);
-    });
-  })
+  }
 });

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -6,6 +6,7 @@ import {
   skip
 } from 'qunit';
 import startApp from '../helpers/start-app';
+import { lookupService } from '../helpers/utils/lookup';
 
 var application;
 const { run } = Ember;
@@ -21,37 +22,29 @@ module('Acceptance: Integration', {
   }
 });
 
-skip('flash messages are rendered', function(assert) {
+test('flash messages are rendered', function(assert) {
   assert.expect(7);
   visit('/');
 
-  assert.ok(find('.alert.alert-success'));
-  assert.equal(find('.alert.alert-success h6').text(), 'Success');
-  assert.equal(find('.alert.alert-success p').text(), 'Route transitioned successfully');
-  assert.equal(find('.alert.alert-success .alert-progressBar').attr('style'), `transition-duration: ${defaultTimeout}ms`);
+  andThen(() => {
+    assert.ok(find('.alert.alert-success'));
+    assert.equal(find('.alert.alert-success h6').text(), 'Success');
+    assert.equal(find('.alert.alert-success p').text(), 'Route transitioned successfully');
+    assert.equal(find('.alert.alert-success .alert-progressBar').attr('style'), `transition-duration: ${defaultTimeout}ms`);
 
-  assert.ok(find('.alert.alert-warning'));
-  assert.equal(find('.alert.alert-warning h6').text(), 'Warning');
-  assert.equal(find('.alert.alert-warning p').text(), 'It is going to rain tomorrow');
+    assert.ok(find('.alert.alert-warning'));
+    assert.equal(find('.alert.alert-warning h6').text(), 'Warning');
+    assert.equal(find('.alert.alert-warning p').text(), 'It is going to rain tomorrow');
+  });
 });
 
-skip('high priority messages are rendered on top', function(assert) {
+test('high priority messages are rendered on top', function(assert) {
   assert.expect(3);
   visit('/');
 
-  assert.ok(find('.alert'));
-  assert.equal(find('.alert h6').first().text(), 'Warning');
-  assert.equal(find('.alert p').first().text(), 'It is going to rain tomorrow');
-});
-
-test('sticky messages are not removed automatically', function(assert) {
-  assert.expect(4);
-  visit('/');
-
   andThen(() => {
-    assert.ok(find('.alert.alert-danger'));
-    assert.equal(find('.alert').length, 1);
-    assert.equal(find('.alert.alert-danger h6').text(), 'Danger');
-    assert.equal(find('.alert.alert-danger p').text(), 'You went offline');
+    assert.ok(find('.alert'));
+    assert.equal(find('.alert h6').first().text(), 'Warning');
+    assert.equal(find('.alert p').first().text(), 'It is going to rain tomorrow');
   });
 });

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -8,11 +8,13 @@ export default Ember.Route.extend({
 
     flashMessages.success('Route transitioned successfully', {
       priority     : 500,
-      showProgress : true
+      showProgress : true,
+      sticky       : false
     });
 
     flashMessages.warning('It is going to rain tomorrow', {
-      priority : 1000
+      priority : 1000,
+      sticky   : false
     });
 
     flashMessages.danger('You went offline', { sticky: true });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,7 +20,7 @@ module.exports = function(environment) {
     flashMessageDefaults: {
       timeout            : 1,
       priority           : 100,
-      sticky             : false,
+      sticky             : true,
       showProgress       : false,
       type               : 'info',
       types              : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary', 'foo' ],

--- a/tests/helpers/utils/lookup.js
+++ b/tests/helpers/utils/lookup.js
@@ -1,0 +1,7 @@
+export function lookupService(application, serviceName) {
+  return application.__container__.lookup(`service:${serviceName}`);
+}
+
+export function lookupComponent(application, componentName) {
+  return application.__container__.lookup(`component:${componentName}`);
+}

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -36,3 +36,43 @@ test('it renders with the right props', function(assert) {
   assert.equal(component.get('flashType'), 'Test');
   assert.equal(component.get('progressDuration'), `transition-duration: ${flash.get('timeout')}ms`);
 });
+
+test('#showProgressBar is read only', function(assert) {
+  assert.expect(2);
+
+  const component = this.subject({ flash });
+  this.render();
+
+  assert.throws(() => {
+    component.set('showProgressBar', false);
+  });
+
+  assert.equal(component.get('showProgressBar'), true);
+});
+
+
+test('#flashType is read only', function(assert) {
+  assert.expect(2);
+
+  const component = this.subject({ flash });
+  this.render();
+
+  assert.throws(() => {
+    component.set('flashType', 'invalid');
+  });
+
+  assert.equal(component.get('flashType'), 'Test');
+});
+
+test('#progressDuration is read only', function(assert) {
+  assert.expect(2);
+
+  const component = this.subject({ flash });
+  this.render();
+
+  assert.throws(() => {
+    component.set('progressDuration', 'derp');
+  });
+
+  assert.equal(component.get('progressDuration'), `transition-duration: ${flash.get('timeout')}ms`);
+});

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -3,10 +3,12 @@ import { module, test } from 'qunit';
 import Ember from 'ember';
 import FlashMessage from 'ember-cli-flash/flash/object';
 
-var testTimerDuration = 50;
-var { run }           = Ember;
-var flash             = null;
-var SANDBOX           = {};
+const { forEach } = Ember.EnumerableUtils;
+
+let testTimerDuration = 50;
+let { run }           = Ember;
+let flash             = null;
+let SANDBOX           = {};
 
 module('FlashMessageObject', {
   beforeEach() {
@@ -30,13 +32,17 @@ test('#_destroyLater sets a timer', function(assert) {
 
 test('#_destroyLater destroys the message after the timer has elapsed', function(assert) {
   const done = assert.async();
-  assert.expect(2);
+  assert.expect(3);
 
   run.later(() => {
     assert.equal(flash.get('isDestroyed'), true);
     assert.equal(flash.get('timer'), null);
     done();
   }, testTimerDuration * 2);
+
+  flash.one('destroyMessage', (isDestroyed) => {
+    assert.equal(isDestroyed, true);
+  });
 });
 
 test('#_destroyLater does not destroy the message if it is sticky', function(assert) {
@@ -67,3 +73,24 @@ test('#destroyMessage deletes the message and timer', function(assert) {
   assert.equal(flash.get('isDestroyed'), true);
   assert.equal(flash.get('timer'), null);
 });
+
+test('#is{type}Type aliases are read only', function(assert) {
+  const typeAliases = [
+    'isSuccessType',
+    'isInfoType',
+    'isWarningType',
+    'isDangerType',
+    'isErrorType'
+  ];
+
+  assert.expect(typeAliases.length);
+
+  run(() => {
+    forEach(typeAliases, (alias) => {
+      assert.throws(() => {
+        flash.set(alias, 'derp');
+      });
+    });
+  });
+});
+

--- a/tests/unit/services/flash-messages-service-test.js
+++ b/tests/unit/services/flash-messages-service-test.js
@@ -3,11 +3,12 @@ import Ember from 'ember';
 import config from '../../../config/environment';
 import FlashMessagesService from 'ember-cli-flash/services/flash-messages-service';
 
-var service;
-var SANDBOX = {};
-const { run } = Ember;
-
+const { run }      = Ember;
 const { classify } = Ember.String;
+const { forEach }  = Ember.EnumerableUtils;
+
+let service;
+let SANDBOX = {};
 
 module('FlashMessagesService', {
   beforeEach() {
@@ -21,6 +22,7 @@ module('FlashMessagesService', {
       service.get('queue').clear();
       service.destroy();
     });
+
     service = null;
     SANDBOX = {};
   }
@@ -49,6 +51,19 @@ test('#arrangedQueue returns an array of flash messages, sorted by priority', fu
 
   assert.equal(service.get('arrangedQueue.length'), 3);
   assert.equal(service.get('arrangedQueue.0.priority'), 300);
+});
+
+test('#arrangedQueue is read only', function(assert) {
+  assert.expect(2);
+
+  run(() => {
+    service.success('foo');
+    assert.throws(() => {
+      service.set('arrangedQueue', []);
+    });
+  });
+
+  assert.equal(service.get('arrangedQueue.length'), 1);
 });
 
 test('#add adds a custom message', function(assert) {
@@ -137,12 +152,12 @@ test('#_registerTypes registers new types', function(assert) {
 
 test('#_initTypes registers default types on init', function(assert) {
   const defaultTypes = [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ];
-  let expectLength   = defaultTypes.length * 2;
+  const expectLength   = defaultTypes.length * 2;
 
   assert.expect(expectLength);
 
-  defaultTypes.forEach((type) => {
-    let method = service[type];
+  forEach(defaultTypes, (type) => {
+    const method = service[type];
 
     assert.ok(method);
     assert.equal(Ember.typeOf(method), 'function');
@@ -150,10 +165,10 @@ test('#_initTypes registers default types on init', function(assert) {
 });
 
 test("passing applications specific options via add()", function(assert) {
-  run(()=> {
+  run(() => {
     SANDBOX.flash = service.add({
-      message: "here's an option you may or may not know",
-      appOption: 'ohai'
+      message   : "here's an option you may or may not know",
+      appOption : 'ohai'
     });
   });
 
@@ -163,11 +178,12 @@ test("passing applications specific options via add()", function(assert) {
 });
 
 test("passing application specific options via specific message type", function(assert) {
-  run(()=> {
-    SANDBOX.flash = service.info("you can pass app options this way too", {
+  run(() => {
+    SANDBOX.flash = service.info('you can pass app options this way too', {
       appOption: 'we meet again app-option'
     });
   });
+
   assert.equal(service.get('queue.length'), 1);
   assert.equal(service.get('queue.0'), SANDBOX.flash);
   assert.equal(service.get('queue.0.appOption'), 'we meet again app-option');
@@ -176,11 +192,11 @@ test("passing application specific options via specific message type", function(
 test('#_setDefaults sets the correct defaults for service properties', function(assert) {
   const flashMessageDefaults = config.flashMessageDefaults;
   const configOptions        = Ember.keys(flashMessageDefaults);
-  let expectLength           = configOptions.length;
+  const expectLength           = configOptions.length;
 
   assert.expect(expectLength);
 
-  configOptions.forEach((option) => {
+  forEach(configOptions, (option) => {
     const classifiedKey = `default${classify(option)}`;
     const defaultValue  = service[classifiedKey];
     const configValue   = flashMessageDefaults[option];


### PR DESCRIPTION
Addresses points from #44

- props that should be readOnly are now actually readOnly
- added tests for readOnly props in flash model
- stop using var in tests
- use Ember.EnumerableUtils instead of array prototype methods
- added tests for readOnly prop on service
- reorganised variable declarations in service test
- added tests for readOnly props on component
- fixed missing super
- fixed setting state on prototype
- fixed indentation issue in service
- removed redundant private method in flash model
- updated tests
- addded Evented mixin to flash object
- added lookup helpers in testing
- made default sticky in testing true