### PR TITLE
Added extendTimeout as a configuration option to make animation possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ You can also pass in options to custom messages:
 
 ```javascript
 Ember.get(this, 'flashMessages').add({
-  message      : 'I like alpacas',
-  type         : 'alpaca'
-  timeout      : 500,
-  priority     : 200,
-  sticky       : true,
-  showProgress : true
+  message            : 'I like alpacas',
+  type               : 'alpaca'
+  timeout            : 500,
+  priority           : 200,
+  sticky             : true,
+  showProgress       : true,
+  extendedTimeout    : 500,
 });
 
 Ember.get(this, 'flashMessages').success('This is amazing', {
@@ -115,6 +116,13 @@ Ember.get(this, 'flashMessages').success('This is amazing', {
   Default: `false`
 
   To show a progress bar in the flash message, set this to true.
+
+- `extendedTimeout?: number`
+
+  Default: `0`
+
+  Number of milliseconds before a flash message is removed to add the class 'exiting' to the element.  This can be used to animate the removal of messages with a transition.
+
 
 ### Arbitrary options
 You can also add arbitrary options to messages:

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -13,10 +13,11 @@ const { escapeExpression } = Ember.Handlebars.Utils;
 const { SafeString } = Ember.Handlebars;
 
 export default Ember.Component.extend({
-  classNameBindings: [ 'alertType', 'active' ],
+  classNameBindings: [ 'alertType', 'active', 'exiting'],
   active: true,
   messageStyle: 'bootstrap',
   showProgressBar: computed.readOnly('flash.showProgress'),
+  exiting: computed.readOnly('flash.exiting'),
 
   alertType: computed('flash.type', {
     get() {

--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -8,6 +8,7 @@ const {
   getWithDefault,
   run,
   on,
+  setProperties,
   Evented
 } = Ember;
 
@@ -19,8 +20,11 @@ export default Ember.Object.extend(Evented, {
   isErrorType: computed.equal('type', 'error').readOnly(),
 
   defaultTimeout: computed.readOnly('flashService.defaultTimeout'),
+  defaultExtendedTimeout: computed.readOnly('flashService.defaultExtendedTimeout'),
   queue: computed.readOnly('flashService.queue'),
   timer: null,
+  exitingTimer: null,
+  exiting: false,
 
   destroyMessage() {
     const queue = get(this, 'queue');
@@ -50,16 +54,38 @@ export default Ember.Object.extend(Evented, {
     }
   },
 
+  setExiting() {
+    const exitingTimer = get(this, 'exitingTimer');
+    const isDestroying = get(this, 'isDestroying');
+    const isDestroyed = get(this, 'isDestroyed');
+
+    if (!isDestroyed && !isDestroying) {
+      setProperties(this, {
+        exiting: true,
+        exitingTimer: null
+      });
+    }
+    if (exitingTimer) {
+      run.cancel(exitingTimer);
+    }
+  },
+
   // private
   _destroyLater: on('init', function() {
     if (get(this, 'sticky')) {
       return;
     }
 
+    const defaultExtendedTimeout = get(this, 'defaultExtendedTimeout');
+    const extendedTimeout = getWithDefault(this, 'extendedTimeout', defaultExtendedTimeout);
+
     const defaultTimeout = get(this, 'defaultTimeout');
     const timeout = getWithDefault(this, 'timeout', defaultTimeout);
-    const destroyTimer = run.later(this, 'destroyMessage', timeout);
+
+    const destroyTimer = run.later(this, 'destroyMessage', timeout + extendedTimeout);
+    const exitingTimer = run.later(this, 'setExiting', timeout);
 
     set(this, 'timer', destroyTimer);
+    set(this, 'exitingTimer', exitingTimer);
   })
 });

--- a/addon/services/flash-messages-service.js
+++ b/addon/services/flash-messages-service.js
@@ -58,7 +58,8 @@ export default Ember.Service.extend({
       type,
       priority,
       sticky,
-      showProgress
+      showProgress,
+      extendedTimeout,
     } = options;
 
     return FlashMessage.create(merge(options, {
@@ -68,7 +69,8 @@ export default Ember.Service.extend({
       timeout: timeout || get(this, 'defaultTimeout'),
       priority: priority || get(this, 'defaultPriority'),
       sticky: sticky || get(this, 'defaultSticky'),
-      showProgress: showProgress || get(this, 'defaultShowProgress')
+      showProgress: showProgress || get(this, 'defaultShowProgress'),
+      extendedTimeout: extendedTimeout || get(this, 'defaultExtendedTimeout')
     }));
   },
 
@@ -98,7 +100,7 @@ export default Ember.Service.extend({
     Ember.assert('The flash type cannot be undefined', type);
 
     this[type] = ((message, options = {}) => {
-      const { timeout, priority, sticky, showProgress } = options;
+      const { timeout, priority, sticky, showProgress, extendedTimeout } = options;
 
       return this._addToQueue(merge(options, {
         message,
@@ -106,7 +108,8 @@ export default Ember.Service.extend({
         timeout,
         priority,
         sticky,
-        showProgress
+        showProgress,
+        extendedTimeout
       }));
     });
   },

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function(/* environment, appConfig */) {
       priority           : 100,
       sticky             : false,
       showProgress       : false,
+      extendedTimeout    : 0,
       type               : 'info',
       types              : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ],
       injectionFactories : [ 'route', 'controller', 'view', 'component' ]

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -22,6 +22,7 @@ module.exports = function(environment) {
       priority           : 100,
       sticky             : true,
       showProgress       : false,
+      extendedTimeout    : 0,
       type               : 'info',
       types              : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary', 'foo' ],
       injectionFactories : [ 'route', 'controller', 'view', 'component' ]

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -19,6 +19,7 @@ moduleForComponent('flash-message', 'FlashMessageComponent', {
       message: 'test',
       type: 'test',
       timeout: 50,
+      extendedTimeout: 5000,
       showProgress: true
     });
   },
@@ -52,7 +53,8 @@ test('read only methods cannot be set', function(assert) {
     component.setProperties({
       alertType: 'invalid',
       flashType: 'invalid',
-      progressDuration: 'derp'
+      progressDuration: 'derp',
+      extendedTimeout: 'nope'
     });
   });
 
@@ -62,5 +64,17 @@ test('read only methods cannot be set', function(assert) {
   });
   assert.throws(() => {
     component.set('hasBlock', true);
+  });
+});
+
+test('exiting the flash object sets exiting on the component', function(assert) {
+  assert.expect(2);
+
+  const component = this.subject({ flash });
+  this.render();
+  assert.ok(!component.get('exiting'));
+  run(() => {
+    flash.set('exiting' , true);
+    assert.ok(component.get('exiting'));
   });
 });

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -94,3 +94,27 @@ test('#is{type}Type aliases are read only', function(assert) {
   });
 });
 
+test('#_destroyLater sets a exitingTimer when extendedTimeout is set', function(assert) {
+  const exitFlash = FlashMessage.create({
+    extendedTimeout: 1000
+  });
+  assert.ok(exitFlash.get('exitingTimer'));
+});
+
+test('#_destroyLater sets exiting after the timer has elapsed', function(assert) {
+  const done = assert.async();
+  const oneSecond = 1000;
+
+  const exitFlash = FlashMessage.create({
+    timeout: oneSecond,
+    extendedTimeout: oneSecond
+  });
+  assert.expect(3);
+  assert.equal(exitFlash.get('exiting'), false);
+
+  run.later(() => {
+    assert.equal(exitFlash.get('exiting'), true);
+    assert.equal(exitFlash.get('exitingTimer'), null);
+    done();
+  }, oneSecond + 50);
+});


### PR DESCRIPTION
### what works
My solution to fix #52

Setting disappearTimeout on a message (or in the config) will cause the class
‘disappearing’ to be added to the message after the timeout.  This
should allow for CSS animation to take place before the message element
is destroyed like:

```scss
.alert {
  opacity: 1;
  transition: all 2s linear;

  &.disappearing {
    opacity: 0;
  }
}
```
### what needs work
I kicked around the names for the option *disappearTimeout* and the class *disappearing* with a few people around the office and this is the best we could come up with.  Other ideas would be welcome. 

The way you are using services, objects, and components here is foreign territory for me.  So there are areas where I :monkey: copied for sure.  I got some great help on the ember slack channel from *cody.mcculloch* and *davidpett*.  Thanks to them if any of this is right.

I wrote an acceptance test in tests/acceptance/integration-test.js but I wasn't able to get it running, you can see it is commented out.  For some reason my message was always marked as sticky so the timeouts never get set.  Any idea why that would happen?  Maybe unit tests cover the case sufficiently, your call.

Lastly my editor did some white space cleanup in README.  If you liked it the way it was I can put it back.