### PR TITLE
Add active class to flash messages upon DOM insertion

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -22,7 +22,7 @@ const {
 export default Ember.Component.extend({
   layout,
   classNameBindings: [ 'alertType', 'active', 'exiting'],
-  active: true,
+  active: false,
   messageStyle: 'bootstrap',
   showProgressBar: computed.readOnly('flash.showProgress'),
   exiting: computed.readOnly('flash.exiting'),
@@ -60,6 +60,13 @@ export default Ember.Component.extend({
       return this;
     }
   }),
+
+  didInsertElement() {
+    this._super(...arguments);
+    Ember.run.later(() => {
+      this.set('active', true);
+    }, 0);
+  },
 
   progressDuration: computed('flash.showProgress', {
     get() {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -516,8 +516,8 @@ hr {
 .alert .alert-progressBar {
   background: white;
   width: 0%;
-  transform-property: width;
-  transition-timing-function: linear;
-  -webkit-transform-property: width;
+  -webkit-transition-property: width;
+  transition-property: width;
   -webkit-transition-timing-function: linear;
+  transition-timing-function: linear;
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,6 +17,13 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+    contentSecurityPolicy: {
+      'img-src': '*',
+      'connect-src': '*',
+      'font-src': '*',
+      'script-src': '\'unsafe-inline\' *',
+      'style-src': '\'unsafe-inline\' *'
+    },
     flashMessageDefaults: {
       timeout            : 1,
       priority           : 100,

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -30,17 +30,21 @@ moduleForComponent('flash-message', 'FlashMessageComponent', {
 });
 
 test('it renders with the right props', function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
   const component = this.subject({ flash });
   assert.equal(component._state, 'preRender');
 
   this.render();
   assert.equal(component._state, 'inDOM');
-  assert.equal(component.get('active'), true);
+  assert.equal(component.get('active'), false);
   assert.equal(component.get('alertType'), 'alert alert-test');
   assert.equal(component.get('flashType'), 'Test');
   assert.equal(component.get('progressDuration'), `transition-duration: ${flash.get('timeout')}ms`);
+
+  Ember.run.later(() => {
+    assert.equal(component.get('active'), true);
+  }, 0);
 });
 
 test('read only methods cannot be set', function(assert) {


### PR DESCRIPTION
In order to make the CSS animation work properly, some style has to change after inserting the flash message into the DOM. Setting active to true doesn't have the desired effect, so (I think) progress bars have never worked.

