### PR TITLE
Adds the ability to prevent duplicate messages from being added

### DIFF
--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -7,7 +7,7 @@ const {
   Evented,
   computed,
   on,
-  run,
+  run
 } = Ember;
 
 export default Ember.Object.extend(Evented, {
@@ -46,6 +46,8 @@ export default Ember.Object.extend(Evented, {
   },
 
   // private
+  _guid: customComputed.guidFor('message').readOnly(),
+
   _setInitialState: on('init', function() {
     if (get(this, 'sticky')) {
       return;

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -4,6 +4,7 @@ const get = Ember.get;
 const {
   computed,
   typeOf,
+  guidFor: emberGuidFor,
   A: emberArray
 } = Ember;
 
@@ -27,4 +28,14 @@ export function add(...dependentKeys) {
   });
 
   return computedFunc.property.apply(computedFunc, dependentKeys);
+}
+
+export function guidFor(dependentKey) {
+  return computed(dependentKey, {
+    get() {
+      const value = get(this, dependentKey);
+
+      return emberGuidFor(value);
+    }
+  });
 }

--- a/circle.yml
+++ b/circle.yml
@@ -4,17 +4,8 @@ machine:
   node:
     version: 0.12
 
-test:
-  post:
-    - mkdir -p $CIRCLE_TEST_REPORTS/QUnit
-    - cp tests/reports/* $CIRCLE_TEST_REPORTS/QUnit/
-
 dependencies:
   override:
-    - npm install -g bower ember-cli@0.2.4
+    - npm install -g bower
     - npm install
     - bower install
-
-notify:
-  webhooks:
-    - url: https://webhooks.gitter.im/e/77cfd25de83430ea669a

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,14 +5,27 @@
 module.exports = function(/* environment, appConfig */) {
   return {
     flashMessageDefaults: {
-      timeout            : 3000,
-      priority           : 100,
-      sticky             : false,
-      showProgress       : false,
-      extendedTimeout    : 0,
-      type               : 'info',
-      types              : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ],
-      injectionFactories : [ 'route', 'controller', 'view', 'component' ]
+      timeout: 3000,
+      extendedTimeout: 0,
+      priority: 100,
+      sticky: false,
+      showProgress: false,
+      type: 'info',
+      types: [
+        'success',
+        'info',
+        'warning',
+        'danger',
+        'alert',
+        'secondary'
+      ],
+      injectionFactories: [
+        'route',
+        'controller',
+        'view',
+        'component'
+      ],
+      preventDuplicates: false
     }
   };
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -25,14 +25,28 @@ module.exports = function(environment) {
       'style-src': '\'unsafe-inline\' *'
     },
     flashMessageDefaults: {
-      timeout            : 1,
-      priority           : 100,
-      sticky             : true,
-      showProgress       : false,
-      extendedTimeout    : 0,
-      type               : 'info',
-      types              : [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary', 'foo' ],
-      injectionFactories : [ 'route', 'controller', 'view', 'component' ]
+      timeout: 1,
+      extendedTimeout: 0,
+      priority: 100,
+      sticky: true,
+      showProgress: false,
+      type: 'info',
+      types: [
+        'success',
+        'info',
+        'warning',
+        'danger',
+        'alert',
+        'secondary',
+        'foo'
+      ],
+      injectionFactories: [
+        'route',
+        'controller',
+        'view',
+        'component'
+      ],
+      preventDuplicates: false
     }
   };
 

--- a/tests/unit/utils/computed-test.js
+++ b/tests/unit/utils/computed-test.js
@@ -6,7 +6,7 @@ const get = Ember.get;
 
 module('Unit | Utility | computed');
 
-test('#add adds dependentKeys that are numbers together', function(assert) {
+test('#add adds `dependentKeys` that are numbers together', function(assert) {
   const expectedResult = 60;
   const Person = Ember.Object.extend({
     scores: computed.add('first', 'second', 'third', 'fourth')
@@ -18,5 +18,16 @@ test('#add adds dependentKeys that are numbers together', function(assert) {
     fourth: 'foo'
   });
   const result = get(person, 'scores');
-  assert.equal(result, expectedResult, 'it adds dependentKeys that are numbers together');
+  assert.equal(result, expectedResult, 'it adds `dependentKeys` that are numbers together');
+});
+
+test('#guidFor adds generates a guid for a `dependentKey`', function(assert) {
+  const Flash = Ember.Object.extend({
+    _guid: computed.guidFor('message')
+  });
+  const flash = Flash.create({
+    message: 'I like pie'
+  });
+  const result = get(flash, '_guid');
+  assert.ok(result, 'it generated a guid for `dependentKey`');
 });


### PR DESCRIPTION
- Fixed an issue where default `type` was not being applied correctly
- Adds the ability to set a `preventDuplicates` default on the service to prevent duplicate messages (by `message`) from being added
- Reorganized README