### PR TITLE
update to remove ember 2.1 deprecation

### DIFF
--- a/app/initializers/flash-messages.js
+++ b/app/initializers/flash-messages.js
@@ -1,6 +1,8 @@
 import config from '../config/environment';
 
-export function initialize(_container, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
+
   const { flashMessageDefaults } = config;
   const { injectionFactories } = flashMessageDefaults;
 


### PR DESCRIPTION
This PR removes a [deprecation introduced in Ember 2.1](http://emberjs.com/deprecations/v2.x/#toc_initializer-arity).