### PR TITLE
Update ember-new-computed to allow a bit more flexibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-new-computed": "1.0.2"
+    "ember-new-computed": "^1.0.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",


### PR DESCRIPTION
This does not fix the issue reported in https://github.com/poteto/ember-cli-flash/issues/92, but if all consumers of ember-new-computed used SemVer allowed drifting versions we should be able to avoid issues of different deps clobbering others.