### PR TITLE
Fix warn deprecation and bad cp

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -10,7 +10,7 @@ const {
   run,
   on,
   get,
-  set,
+  set
 } = Ember;
 const {
   readOnly,
@@ -38,11 +38,7 @@ export default Component.extend({
       return `${prefix}${flashType}`;
     },
 
-    set() {
-      warn('`alertType` is read only');
-
-      return this;
-    }
+    set: readOnlySet
   }),
 
   flashType: computed('flash.type', {
@@ -52,11 +48,7 @@ export default Component.extend({
       return classify(flashType);
     },
 
-    set() {
-      warn('`flashType` is read only');
-
-      return this;
-    }
+    set: readOnlySet
   }),
 
   _setActive: on('didInsertElement', function() {
@@ -76,9 +68,7 @@ export default Component.extend({
       return htmlSafe(`transition-duration: ${duration}ms`);
     },
 
-    set() {
-      warn('`progressDuration` is read only');
-    }
+    set: readOnlySet
   }),
 
   click() {
@@ -101,3 +91,12 @@ export default Component.extend({
 
   hasBlock: bool('template').readOnly()
 });
+
+function readOnlySet(key, value, oldValue) {
+  warn(`\`${key}\` is read only`, {
+    id: `ember-cli-flash.${key}-readonly`
+  });
+
+  // Ember 1.11 does not pass `oldValue`
+  return arguments.length === 3 ? oldValue : this.get(key);
+}

--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -129,7 +129,9 @@ export default Service.extend({
     const guid = get(flashInstance, '_guid');
 
     if (preventDuplicates && this._hasDuplicate(guid)) {
-      warn('Attempting to add a duplicate message to the Flash Messages Service');
+      warn('Attempting to add a duplicate message to the Flash Messages Service', {
+        id: 'ember-cli-flash.duplicate-message'
+      });
       return;
     }
 

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -7,6 +7,7 @@ import FlashMessage from 'ember-cli-flash/flash/object';
 
 const {
   setProperties,
+  getProperties,
   run,
   get,
   set
@@ -51,22 +52,28 @@ test('it renders with the right props', function(assert) {
   });
 });
 
-test('read only methods cannot be set', function(assert) {
-  assert.expect(3);
+test('read only computed properties cannot be set', function(assert) {
+  assert.expect(4);
 
   const component = this.subject({ flash });
   this.render();
+
+  const getSnapshot = () => getProperties(component, 'alertType', 'flashType', 'progressDuration');
+
+  const beforeSet = getSnapshot();
 
   run(() => {
     setProperties(component, {
       alertType: 'invalid',
       flashType: 'invalid',
-      progressDuration: 'derp',
-      extendedTimeout: 'nope'
+      progressDuration: 'derp'
     });
   });
 
+  const afterSet = getSnapshot();
+
   assert.deepEqual(get(component, 'flash'), flash);
+  assert.deepEqual(afterSet, beforeSet);
   assert.throws(() => {
     set(component, 'showProgressBar', true);
   });


### PR DESCRIPTION
Fixes two issues:

- Ember 2.1 deprecation warnings for calling `Ember.warn()` without an options hash with id
- Computed properties that sets itself to the object they are on, after calling `Ember.set()` with any value on them.

For detail please read my commit messages.
Cherry picking 9bb1113 from my repo and running it against develop would fail.