### PR TITLE
Starts the timeout on message render instead of creation

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -11,6 +11,7 @@ const {
   on,
   get,
   set,
+  observer
 } = Ember;
 const {
   readOnly,
@@ -58,6 +59,14 @@ export default Component.extend({
       return this;
     }
   }),
+
+  // Observer used here for backwards compatibility with Ember 1.11/1.12, replace
+  // with on('didRender') once possible.
+  _startTimers: on('didInsertElement', observer('flash', function() {
+    run.schedule('afterRender', this, () => {
+      get(this, 'flash').startTimer();
+    });
+  })),
 
   _setActive: on('didInsertElement', function() {
     run.scheduleOnce('afterRender', this, () => {

--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -20,10 +20,8 @@ export default EmberObject.extend(Evented, {
   exitTimer: null,
   exiting: false,
 
-  init() {
-    this._super(...arguments);
-
-    if (get(this, 'sticky')) {
+  startTimer() {
+    if (get(this, 'timer') || get(this, 'sticky')) {
       return;
     }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,7 +24,7 @@
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
-    <script src="testem.js"></script>
+    <script src="testem.js" integrity="" ></script>
     <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -75,6 +75,16 @@ test('read only methods cannot be set', function(assert) {
   });
 });
 
+test('it starts the flash timer on render', function(assert) {
+  assert.expect(2);
+
+  this.subject({ flash });
+  assert.equal(get(flash, 'timer'), undefined, 'it initializes with without a timer set');
+
+  this.render();
+  assert.ok(get(flash, 'timer'), 'it starts the timer on render');
+});
+
 test('exiting the flash object sets exiting on the component', function(assert) {
   assert.expect(2);
 

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -29,7 +29,9 @@ module('FlashMessageObject', {
   }
 });
 
-test('it sets a timer after init', function(assert) {
+test('it sets a timer when startTimer is called', function(assert) {
+  flash.startTimer();
+
   assert.ok(flash.get('timer'));
 });
 
@@ -37,6 +39,8 @@ test('it destroys the message after the timer has elapsed', function(assert) {
   let result;
   const done = assert.async();
   assert.expect(3);
+
+  flash.startTimer();
 
   flash.on('didDestroyMessage', () => {
     result = 'foo';
@@ -62,6 +66,8 @@ test('it does not destroy the message if it is sticky', function(assert) {
     sticky: true
   });
 
+  stickyFlash.startTimer();
+
   run.later(() => {
     assert.equal(get(stickyFlash, 'isDestroyed'), false, 'it is not destroyed');
     done();
@@ -83,6 +89,9 @@ test('it sets an `exitTimer` when `extendedTimeout` is set', function(assert) {
   const exitFlash = FlashMessage.create({
     extendedTimeout: testTimerDuration
   });
+
+  exitFlash.startTimer();
+
   assert.ok(exitFlash.get('exitTimer'));
 });
 
@@ -94,6 +103,8 @@ test('it sets `exiting` to true after the timer has elapsed', function(assert) {
     timeout: testTimerDuration,
     extendedTimeout: testTimerDuration
   });
+
+  exitFlash.startTimer();
 
   run.later(() => {
     assert.equal(exitFlash.get('exiting'), true, 'it sets `exiting` to true');


### PR DESCRIPTION
@poteto Changes the behavior so that messages will start timeout when they are rendered rather than when they are created, allowing for sequencing and more fine tuned control by users.

Wasn't sure if this would constitute a major or minor version bump! Could argue that it may break older behavior, but I find that doubtful unless people were using `flash` objects without the `flash-message` component. Let me know and I'll bump `package.json` accordingly.