### PR TITLE
Add active class in run.next instead of afterRender queue

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -60,7 +60,7 @@ export default Component.extend({
   }),
 
   _setActive: on('didInsertElement', function() {
-    run.scheduleOnce('afterRender', this, () => {
+    run.next(this, () => {
       set(this, 'active', true);
     });
   }),

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -10,7 +10,7 @@ const {
   run,
   on,
   get,
-  set,
+  set
 } = Ember;
 const {
   readOnly,

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -46,7 +46,7 @@ test('it renders with the right props', function(assert) {
   assert.equal(get(component, 'flashType'), 'Test', 'it has the right `flashType`');
   assert.equal(get(component, 'progressDuration'), `transition-duration: ${flash.get('timeout')}ms`, 'it has the right `progressDuration`');
 
-  run(() => {
+  run.next(() => {
     assert.equal(get(component, 'active'), true, 'it sets `active` to true after rendering');
   });
 });


### PR DESCRIPTION
Currently, the active class is added at the exact same time the message is
rendered (despite the afterRender queue). This will ensure that the active
class is added 1ms after it is inserted into the DOM, thus triggering any CSS
transitions from naked to active states.