### PR TITLE
Fix calling set on destroyed object error

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -15,6 +15,10 @@ const {
   readOnly,
   bool
 } = computed;
+const {
+  next,
+  cancel
+} = run;
 
 export default Component.extend({
   layout,
@@ -49,9 +53,10 @@ export default Component.extend({
   }),
 
   _setActive: on('didInsertElement', function() {
-    run.next(this, () => {
+    const pendingSet = next(this, () => {
       set(this, 'active', true);
     });
+    set(this, 'pendingSet', pendingSet);
   }),
 
   progressDuration: computed('flash.showProgress', {
@@ -73,6 +78,7 @@ export default Component.extend({
   willDestroy() {
     this._super();
     this._destroyFlashMessage();
+    cancel(get(this, 'pendingSet'));
   },
 
   // private

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -1,0 +1,36 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import FlashMessage from 'ember-cli-flash/flash/object';
+
+moduleForComponent('flash-message', 'Integration | Component | flash message', {
+  integration: true
+});
+
+test('it renders a flash message', function(assert) {
+  this.set('flash', FlashMessage.create({ message: 'hi', sticky: true }));
+
+  this.render(hbs`
+    {{#flash-message flash=flash as |component flash|}}
+      {{flash.message}}
+    {{/flash-message}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'hi');
+});
+
+test('it does not error when quickly removed from the DOM', function(assert) {
+  this.set('flash', FlashMessage.create({ message: 'hi', sticky: true }));
+  this.set('flag', true);
+
+  this.render(hbs`
+    {{#if flag}}
+      {{#flash-message flash=flash as |component flash|}}
+        {{flash.message}}
+      {{/flash-message}}
+    {{/if}}
+  `);
+
+  this.set('flag', false);
+
+  assert.ok(this.get('flash').isDestroyed, 'Flash Object isDestroyed');
+});


### PR DESCRIPTION
I have a login route that renders flash messages in a certain part of the template. Then the primary parent route of the application renders flash messages again. I was getting a "cannot call set on destroyed object" from [this code](https://github.com/poteto/ember-cli-flash/blob/1.3.12/addon/components/flash-message.js#L53).

I added a component integration test to show the issue: after a component is torn down, `_setActive` still tries to change a property on that component. 

The simple fix is to check for `isDestroyed` on that component, but probably there is a more wholistic refactor needed.