### PR TITLE
Compute guid on .toString() version of the message.

### DIFF
--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -35,7 +35,7 @@ export function guidFor(dependentKey) {
     get() {
       const value = get(this, dependentKey);
 
-      return emberGuidFor(value);
+      return emberGuidFor(value.toString());
     }
   });
 }

--- a/tests/unit/utils/computed-test.js
+++ b/tests/unit/utils/computed-test.js
@@ -21,7 +21,7 @@ test('#add adds `dependentKeys` that are numbers together', function(assert) {
   assert.equal(result, expectedResult, 'it adds `dependentKeys` that are numbers together');
 });
 
-test('#guidFor adds generates a guid for a `dependentKey`', function(assert) {
+test('#guidFor generates a guid for a `dependentKey`', function(assert) {
   const Flash = Ember.Object.extend({
     _guid: computed.guidFor('message')
   });
@@ -30,4 +30,19 @@ test('#guidFor adds generates a guid for a `dependentKey`', function(assert) {
   });
   const result = get(flash, '_guid');
   assert.ok(result, 'it generated a guid for `dependentKey`');
+});
+
+test('#guidFor generates the same guid for a message', function(assert) {
+  const Flash = Ember.Object.extend({
+    _guid: computed.guidFor('message')
+  });
+  const flash = Flash.create({
+    message: new Ember.Handlebars.SafeString('I like pie')
+  });
+  const secondFlash = Flash.create({
+    message: new Ember.Handlebars.SafeString('I like pie')
+  });
+  const result = get(flash, '_guid');
+  const secondResult = get(secondFlash, '_guid');
+  assert.equal(result, secondResult, 'it generated the same guid for messages that compute to the same string');
 });


### PR DESCRIPTION
Hello!

This PR allows using Ember i18n service, or any string which is an Ember SafeString and have the `{ preventDuplicates: true }` work by computing the guid value on the stringified version of the message. Before, it computed the guid directly, so two different instance of the same objet would get different guid. I added a test to cover the case.

Note: there is a test failing, but it was failing before too.