### PR TITLE
Add destroyOnClick option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Ember.get(this, 'flashMessages').add({
   priority: 200,
   sticky: true,
   showProgress: true,
-  extendedTimeout: 500
+  extendedTimeout: 500,
+  destroyOnClick: false
 });
 
 Ember.get(this, 'flashMessages').success('This is amazing', {
@@ -147,6 +148,12 @@ Ember.get(this, 'flashMessages').success('This is amazing', {
   Default: `0`
 
   Number of milliseconds before a flash message is removed to add the class 'exiting' to the element.  This can be used to animate the removal of messages with a transition.
+  
+- `destroyOnClick?: boolean`
+
+  Default: `true`
+
+  By default, flash messages will be destroyed on click.  Disabling this can be useful if the message supports user interaction.
 
 ### Arbitrary options
 You can also add arbitrary options to messages:

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -72,7 +72,11 @@ export default Component.extend({
   }),
 
   click() {
-    this._destroyFlashMessage();
+    const destroyOnClick = getWithDefault(this, 'flash.destroyOnClick', true);
+
+    if (destroyOnClick) {
+      this._destroyFlashMessage();
+    }
   },
 
   willDestroy() {

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -62,3 +62,22 @@ test('exiting the flash object sets exiting on the component', function(assert) 
     assert.ok(get(component, 'exiting'), 'it sets `exiting` to true when the flash object is exiting');
   });
 });
+
+test('it destroys the flash object on click', function(assert) {
+  assert.expect(1);
+  const component = this.subject({ flash });
+  this.render();
+
+  $('.alert').click();
+  assert.ok(get(component, 'flash').isDestroyed, 'it destroys the flash object on click');
+});
+
+test('it does not destroy the flash object when `flash.destroyOnClick` is false', function(assert) {
+  assert.expect(1);
+  flash.destroyOnClick = false;
+  const component = this.subject({ flash });
+  this.render();
+
+  $('.alert').click();
+  assert.notOk(get(component, 'flash').isDestroyed, 'it does not destroy the flash object on click');
+});


### PR DESCRIPTION
This PR adds the following option:

- `destroyOnClick?: number`

  Default: `true`

  By default, flash messages will be destroyed on click.  Disabling this can be useful if the message supports user interaction.
