### PR TITLE
Allow flash-message to not have any default class as prefix

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -34,9 +34,10 @@ export default Component.extend({
     get() {
       const flashType = getWithDefault(this, 'flash.type', '');
       const messageStyle = getWithDefault(this, 'messageStyle', '');
-      let prefix = 'alert alert-';
-
-      if (messageStyle === 'foundation') {
+      let prefix = 'alert-';
+      if (messageStyle === 'bootstrap') {
+        prefix = 'alert alert-';
+      } else if (messageStyle === 'foundation') {
         prefix = 'alert-box ';
       }
 

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -81,3 +81,13 @@ test('it does not destroy the flash object when `flash.destroyOnClick` is false'
   $('.alert').click();
   assert.notOk(get(component, 'flash').isDestroyed, 'it does not destroy the flash object on click');
 });
+
+test('if it receives `messageStyle="notBootstrapNorFoundation"` it doesn\'t has any prefix class', function(assert) {
+  assert.expect(1);
+
+  this.subject({ flash, messageStyle: 'notBootstrapNorFoundation' });
+
+  this.render();
+
+  assert.equal(this.$().attr('class').indexOf('alert '), -1, 'The component has no default classes'); // intentional space
+});


### PR DESCRIPTION
With this change, if the component receives a `messageStyle="one-of-my-own"` it doesn't
generate it just generates an "alert-{{TYPE}}" (instead of "alert alert-{{type}}"), since
that is the styles expected by bootstrap.

The default behavior is still the same, this just allows the user to opt out.

This allows me by example to create my own component that extends from the default one and provide different classes (since in my project the "alert" class is used for another kind of component, and I want to use "flash" instead.

``` js
import FlashMessageComponent from 'ember-cli-flash/components/flash-message';

export default FlashMessageComponent.extend({
  classNames: ['flash'],
  messageStyle: 'custom'
});

```
