### PR TITLE
Remove unnecesary ember-new-computed addon

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/flash-message';
-import computed from 'ember-new-computed';
 
 const {
   String: { classify, htmlSafe },
@@ -10,7 +9,8 @@ const {
   run,
   on,
   get,
-  set
+  set,
+  computed
 } = Ember;
 const {
   readOnly,

--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -1,17 +1,14 @@
 import Ember from 'ember';
 import customComputed from '../utils/computed';
-import computed from 'ember-new-computed';
 
 const {
   Object: EmberObject,
+  computed: { readOnly },
+  run: { later, cancel },
   Evented,
   get,
-  run: { later, cancel },
   set
 } = Ember;
-const {
-  readOnly
-} = computed;
 
 export default EmberObject.extend(Evented, {
   timer: null,

--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import FlashMessage from 'ember-cli-flash/flash/object';
 import objectWithout from '../utils/object-without';
-import computed from 'ember-new-computed';
 
 const {
   Service,
@@ -14,6 +13,7 @@ const {
   warn,
   get,
   set,
+  computed,
   String: { classify },
   A: emberArray
 } = Ember;

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import computed from 'ember-new-computed';
 
 const {
   typeOf,
   get,
+  computed,
   guidFor: emberGuidFor,
   A: emberArray
 } = Ember;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-new-computed": "^1.0.3",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
If this addons is 1.12+ (and I think that it safe to assume it is), this
addon is not needed anymore.
