### PR TITLE
Fix Ember 2.8 deprecations

### DIFF
--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -127,7 +127,7 @@ export default Service.extend({
   },
 
   _hasDuplicate(guid) {
-    return get(this, '_guids').contains(guid);
+    return get(this, '_guids').includes(guid);
   },
 
   _enqueue(flashInstance) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-new-computed": "^1.0.3"
+    "ember-new-computed": "^1.0.3",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/unit/utils/computed-test.js
+++ b/tests/unit/utils/computed-test.js
@@ -37,10 +37,10 @@ test('#guidFor generates the same guid for a message', function(assert) {
     _guid: computed.guidFor('message')
   });
   const flash = Flash.create({
-    message: new Ember.Handlebars.SafeString('I like pie')
+    message: Ember.String.htmlSafe('I like pie')
   });
   const secondFlash = Flash.create({
-    message: new Ember.Handlebars.SafeString('I like pie')
+    message: Ember.String.htmlSafe('I like pie')
   });
   const result = get(flash, '_guid');
   const secondResult = get(secondFlash, '_guid');


### PR DESCRIPTION
Hi! Just a quick PR to knock out some usage that was deprecated in Ember 2.8.

In runtime code, there was one `Enumerable#contains` that I [changed to `includes`](http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains) and added the polyfill for in order to maintain backwards compatibility. 

I also updated a couple instances of `Handlebars.SafeString` [to `String.htmlSafe`](http://emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring) in test code since I was picking over test output for deprecation warnings anyway.