### PR TITLE
Add onDestroy callback method for flash object destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ Ember.get(this, 'flashMessages').add({
   sticky: true,
   showProgress: true,
   extendedTimeout: 500,
-  destroyOnClick: false
+  destroyOnClick: false,
+  onDestroy() {
+    // behavior triggered when flash is destroyed
+  }
 });
 
 Ember.get(this, 'flashMessages').success('This is amazing', {

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Ember.get(this, 'flashMessages').success('This is amazing', {
 
   By default, flash messages will be destroyed on click.  Disabling this can be useful if the message supports user interaction.
 
+- `onDestroy: function`
+
+  Default: `undefined`
+
+  A function to be called when the flash message is destroyed.
+
 ### Arbitrary options
 You can also add arbitrary options to messages:
 

--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -52,6 +52,12 @@ export default EmberObject.extend(Evented, {
   willDestroy() {
     this._cancelAllTimers();
 
+    const onDestroy = get(this, 'onDestroy');
+
+    if (onDestroy) {
+      onDestroy();
+    }
+
     this._super(...arguments);
   },
 

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -166,3 +166,18 @@ test('#resumeTimers resets timers', function(assert) {
 
   assert.notOk(setupTimerStub.called, 'setup timers is not called');
 });
+
+test('it calls `onDestroy` when object is destroyed', function(assert) {
+  assert.expect(1);
+
+  const callbackFlash = FlashMessage.create({
+    extendedTimeout: 1000,
+    onDestroy() {
+      assert.ok(true, 'onDestroy is called');
+    }
+  });
+
+  run(() => {
+    callbackFlash.destroyMessage();
+  });
+});


### PR DESCRIPTION
This PR adds a callback function that can be passed in and called when a flash is destroyed.
- [x] Add callback method handler
- [x] Add unit test for destroyed flash object
- [x] Update README for how to use callback

Addresses: https://github.com/poteto/ember-cli-flash/issues/212
