### PR TITLE
add chainable method for returning flash object

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,23 @@ This makes use of the [component helper](http://emberjs.com/blog/2015/03/27/embe
 ```
 
 ### Clearing all messages on screen
-It's best practise to use flash messages sparingly, only when you need to notify the user of something. If you're sending too many messages, and need a way for your users to clear all messages from screen, you can use this method:
+It's best practice to use flash messages sparingly, only when you need to notify the user of something. If you're sending too many messages, and need a way for your users to clear all messages from screen, you can use this method:
 
 ```javascript
 Ember.get(this, 'flashMessages').clearMessages();
 ```
+
+### Returning flash object
+The flash message service is designed to be Fluent, allowing you to chain methods on the service easily. The service should handle most cases but if you want to access the flash object directly, you can use the `getFlashObject` method:
+
+```javascript
+const flashObject = Ember.get(this, 'flashMessages').add({
+  message: 'hola',
+  type: 'foo'
+}).getFlashObject();
+```
+
+You can then manipulate the `flashObject` directly. Note that `getFlashObject` must be the last method in your chain as it returns the flash object directly.
 
 ## Service defaults
 In `config/environment.js`, you can override service defaults in the `flashMessageDefaults` object:

--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -68,6 +68,21 @@ export default Service.extend({
     return this;
   },
 
+  peekFirst() {
+    return get(this, 'queue.firstObject');
+  },
+
+  peekLast() {
+    return get(this, 'queue.lastObject');
+  },
+
+  getFlashObject() {
+    const errorText = 'A flass message must be added before it can be returned';
+    assert(errorText, get(this, 'queue').length);
+
+    return this.peekLast();
+  },
+
   _newFlashMessage(options = {}) {
     assert('The flash message cannot be empty.', options.message);
 

--- a/tests/unit/services/flash-messages-test.js
+++ b/tests/unit/services/flash-messages-test.js
@@ -198,3 +198,26 @@ test('it supports chaining', function(assert) {
   assert.equal(get(service, 'queue.firstObject.message'), 'foo', 'should support chaining');
   assert.equal(get(service, 'queue.lastObject.message'), 'bar', 'should support chaining');
 });
+
+test('it returns flash object when fetched through `getFlashObject`', function(assert) {
+  const { flashMessageDefaults } = config;
+  const flash = service
+    .clearMessages()
+    .add({ message: 'foo' })
+    .getFlashObject();
+
+  assert.equal(get(flash, 'message'), 'foo', 'it returns flash object with correct message');
+  assert.equal(get(flash, 'timeout'), flashMessageDefaults.timeout, 'it returns an object with defaults');
+});
+
+test('it supports public API methods for `peekLast` and `peekFirst`', function(assert) {
+  service.clearMessages();
+
+  assert.equal(typeOf(service.peekLast()), 'undefined', 'returns undefined when queue is empty');
+  assert.equal(typeOf(service.peekFirst()), 'undefined', 'returns undefined when queue is empty');
+
+  service.add({ message: 'foo' }).add({ message: 'bar' });
+
+  assert.equal(service.peekFirst().message, 'foo', 'returns first object from queue');
+  assert.equal(service.peekLast().message, 'bar', 'returns last object from queue');
+});


### PR DESCRIPTION
## What's in this PR
This should address the issue raised by #154.  A fluent API allows for chaining methods, but does not give access to the flash object. For users who want to manipulate the object directly, they can access it with the `getFlashObject` method, which will return the last object added to the queue.

- [x] Add chainable method that returns the flash object
- [x] Add test coverage in service test
- [x] Update Readme to include documentation on `getFlashObject`