### PR TITLE
remove flash.destroy as it fails on latest builds of Ember

### DIFF
--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -26,10 +26,6 @@ moduleForComponent('flash-message', 'FlashMessageComponent', {
   },
 
   afterEach() {
-    run(() => {
-      flash.destroy();
-    });
-
     flash = null;
   }
 });


### PR DESCRIPTION
Master was getting failures when trying to run `flash.destroy()` on unit level tests of our component:
`Assertion Failed: Cannot call writeDeps after the object is destroyed.`