### PR TITLE
version bump to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,56 +5,64 @@ changelog, see the git history.
 
 [npm page](https://www.npmjs.com/package/ember-cli-flash)
 
+## [1.4.0]
+
+  - Add changelog for release notes [220](https://github.com/poteto/ember-cli-flash/pull/220)
+  - Fix failing tests [218](https://github.com/poteto/ember-cli-flash/pull/218)
+  - Update Acceptance test example in README to fail appropriately [217](https://github.com/poteto/ember-cli-flash/pull/217)
+  - Add ability to return flash object [214](https://github.com/poteto/ember-cli-flash/pull/214)
+  - Defer removal of flash message on mouse over [209](https://github.com/poteto/ember-cli-flash/pull/209)
+
 ## [1.3.17]
 
- - Fixed deprecation warnings from Ember 2.8.0 [205](https://github.com/poteto/ember-cli-flash/pull/205)
- - Small updates to README [186](https://github.com/poteto/ember-cli-flash/pull/186)
- - Update Ember-CLI to 2.7.0 [201](https://github.com/poteto/ember-cli-flash/pull/201)
+  - Fixed deprecation warnings from Ember 2.8.0 [205](https://github.com/poteto/ember-cli-flash/pull/205)
+  - Small updates to README [186](https://github.com/poteto/ember-cli-flash/pull/186)
+  - Update Ember-CLI to 2.7.0 [201](https://github.com/poteto/ember-cli-flash/pull/201)
 
 ## [1.3.16]
 
- - Update Ember-CLI to 2.6.1 [169](https://github.com/poteto/ember-cli-flash/pull/169)
- - Add destroyOnClick option [157](https://github.com/poteto/ember-cli-flash/pull/157)
- - Clarify documentation on integration tests [165](https://github.com/poteto/ember-cli-flash/pull/165)
- - Update Travis to use Trust builds
+  - Update Ember-CLI to 2.6.1 [169](https://github.com/poteto/ember-cli-flash/pull/169)
+  - Add destroyOnClick option [157](https://github.com/poteto/ember-cli-flash/pull/157)
+  - Clarify documentation on integration tests [165](https://github.com/poteto/ember-cli-flash/pull/165)
+  - Update Travis to use Trust builds
 
 ## [1.3.15]
 
- - Test against Ember 2.4 and 2.5
+  - Test against Ember 2.4 and 2.5
 
 ## [1.3.14]
 
- - Compute guid on .toString() version of the message [149](https://github.com/poteto/ember-cli-flash/pull/149)
+  - Compute guid on .toString() version of the message [149](https://github.com/poteto/ember-cli-flash/pull/149)
 
 ## [1.3.13]
 
- - Fix calling set on destroyed object error [148](https://github.com/poteto/ember-cli-flash/pull/148)
- - Add demo app [147](https://github.com/poteto/ember-cli-flash/pull/147)
+  - Fix calling set on destroyed object error [148](https://github.com/poteto/ember-cli-flash/pull/148)
+  - Add demo app [147](https://github.com/poteto/ember-cli-flash/pull/147)
 
 ## [1.3.12]
 
- - Fix for apps with no defaults defined [145](https://github.com/poteto/ember-cli-flash/pull/145)
- - Minor fix for exports [144](https://github.com/poteto/ember-cli-flash/pull/144)
+  - Fix for apps with no defaults defined [145](https://github.com/poteto/ember-cli-flash/pull/145)
+  - Minor fix for exports [144](https://github.com/poteto/ember-cli-flash/pull/144)
 
 ## [1.3.11]
 
- - Fix iteration of wrong array initializer [143](https://github.com/poteto/ember-cli-flash/pull/143)
- - Update README with remove of injectionFactories [137](https://github.com/poteto/ember-cli-flash/pull/137)
+  - Fix iteration of wrong array initializer [143](https://github.com/poteto/ember-cli-flash/pull/143)
+  - Update README with remove of injectionFactories [137](https://github.com/poteto/ember-cli-flash/pull/137)
 
 ## [1.3.10]
 
- - Update ember-cli [135](https://github.com/poteto/ember-cli-flash/pull/135)
- - Deprecate use of injectionFactories [134](https://github.com/poteto/ember-cli-flash/pull/134)
+  - Update ember-cli [135](https://github.com/poteto/ember-cli-flash/pull/135)
+  - Deprecate use of injectionFactories [134](https://github.com/poteto/ember-cli-flash/pull/134)
 
 ## [1.3.9]
 
- - Update ember-cli [130](https://github.com/poteto/ember-cli-flash/pull/130)
- - Add active class in run.next [129](https://github.com/poteto/ember-cli-flash/pull/129)
- - Minor JSCS fixes [129](https://github.com/poteto/ember-cli-flash/pull/129)
+  - Update ember-cli [130](https://github.com/poteto/ember-cli-flash/pull/130)
+  - Add active class in run.next [129](https://github.com/poteto/ember-cli-flash/pull/129)
+  - Minor JSCS fixes [129](https://github.com/poteto/ember-cli-flash/pull/129)
 
 ## [1.3.8]
 
- - Fix acceptance test bug due to old blueprint [119](https://github.com/poteto/ember-cli-flash/pull/119)
+  - Fix acceptance test bug due to old blueprint [119](https://github.com/poteto/ember-cli-flash/pull/119)
 
 ## [1.3.7]
 
@@ -62,8 +70,8 @@ changelog, see the git history.
 
 ## [1.3.6]
 
- - Fix syntax error in README for custom messages example [110](https://github.com/poteto/ember-cli-flash/pull/110)
- - Update ember-new-computed for flexibility [109](https://github.com/poteto/ember-cli-flash/pull/109)
+  - Fix syntax error in README for custom messages example [110](https://github.com/poteto/ember-cli-flash/pull/110)
+  - Update ember-new-computed for flexibility [109](https://github.com/poteto/ember-cli-flash/pull/109)
 
 ## [1.3.5]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-flash",
-  "version": "1.3.17",
+  "version": "1.4.0",
   "description": "Simple, highly configurable flash messages for ember-cli",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Closes: #219 

- [x] [Fix Failing Tests]( https://github.com/poteto/ember-cli-flash/pull/218 )
- [x] [Update Acceptance Test Example](https://github.com/poteto/ember-cli-flash/pull/217)
- [x] [Add ability to return flash object](https://github.com/poteto/ember-cli-flash/pull/214)
- [x] [Defer remove on mouse over](https://github.com/poteto/ember-cli-flash/pull/209)
- [x] [Add changelog for release notes](https://github.com/poteto/ember-cli-flash/pull/220)