### PR TITLE
Pass 'close' as closure action

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ moduleFor('route:foo', 'Unit | Route | foo', {
 ```
 
 ## Styling
-This addon is minimal and does not currently ship with a stylesheet. You can style flash messages by targetting the appropriate alert class (Foundation or Bootstrap) in your CSS.
+This addon is minimal and does not currently ship with a stylesheet. You can style flash messages by targeting the appropriate alert class (Foundation or Bootstrap) in your CSS.
 
 ## License
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ It also accepts your own template:
 ```
 
 ### Custom `close` action
-The `close` action is always passed to the component whether it is used or not. It can be used to implement your own close button, such an an `x` in the top-right corner.
+The `close` action is always passed to the component whether it is used or not. It can be used to implement your own close button, such as an `x` in the top-right corner.
 
 When using a custom `close` action, you will want to set `destroyOnClick=false` to override the default (`destroyOnClick=true`). You could do this globally in `flashMessageDefaults`.
 

--- a/README.md
+++ b/README.md
@@ -174,10 +174,11 @@ This makes use of the [component helper](http://emberjs.com/blog/2015/03/27/embe
 
 ```handlebars
 {{#each flashMessages.queue as |flash|}}
-  {{#flash-message flash=flash as |component flash|}}
+  {{#flash-message flash=flash as |component flash close|}}
     {{#if flash.componentName}}
       {{component flash.componentName content=flash.content}}
     {{else}}
+      <span {{action close}}>x</span>
       <h6>{{component.flashType}}</h6>
       <p>{{flash.message}}</p>
     {{/if}}

--- a/README.md
+++ b/README.md
@@ -174,11 +174,10 @@ This makes use of the [component helper](http://emberjs.com/blog/2015/03/27/embe
 
 ```handlebars
 {{#each flashMessages.queue as |flash|}}
-  {{#flash-message flash=flash as |component flash close|}}
+  {{#flash-message flash=flash as |component flash|}}
     {{#if flash.componentName}}
       {{component flash.componentName content=flash.content}}
     {{else}}
-      <a href="#" {{action close}}>close</a>
       <h6>{{component.flashType}}</h6>
       <p>{{flash.message}}</p>
     {{/if}}
@@ -269,6 +268,20 @@ It also accepts your own template:
         <div class="alert-progressBar" style="{{component.progressDuration}}"></div>
       </div>
     {{/if}}
+  {{/flash-message}}
+{{/each}}
+```
+
+### Custom `close` action
+The `close` action is always passed to the component whether it is used or not. It can be used to implement your own close button, such an an `x` in the top-right corner.
+
+When using a custom `close` action, you will want to set `destroyOnClick=false` to override the default (`destroyOnClick=true`). You could do this globally in `flashMessageDefaults`.
+
+```
+{{#each flashMessages.queue as |flash|}}
+  {{#flash-message flash=flash as |component flash close|}}
+    {{flash.message}}
+    <a href="#" {{action close}}>x</a>
   {{/flash-message}}
 {{/each}}
 ```

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This makes use of the [component helper](http://emberjs.com/blog/2015/03/27/embe
     {{#if flash.componentName}}
       {{component flash.componentName content=flash.content}}
     {{else}}
-      <span {{action close}}>x</span>
+      <a href="#" {{action close}}>close</a>
       <h6>{{component.flashType}}</h6>
       <p>{{flash.message}}</p>
     {{/if}}

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -107,5 +107,11 @@ export default Component.extend({
     if (flash) {
       flash.destroyMessage();
     }
+  },
+
+  actions: {
+    close() {
+      this._destroyFlashMessage();
+    }
   }
 });

--- a/addon/templates/components/flash-message.hbs
+++ b/addon/templates/components/flash-message.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  {{yield this flash}}
+  {{yield this flash (action 'close')}}
 {{else}}
   {{flash.message}}
   {{#if showProgressBar}}

--- a/addon/templates/components/flash-message.hbs
+++ b/addon/templates/components/flash-message.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  {{yield this flash (action 'close')}}
+  {{yield this flash (action "close")}}
 {{else}}
   {{flash.message}}
   {{#if showProgressBar}}

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -111,4 +111,29 @@ if (parseFloat(Ember.VERSION) > 2.0) {
 
     clock.restore();
   });
+
+  test('a custom component can use the close closure action', function(assert) {
+    assert.expect(3);
+
+    let destroyMessage = sinon.spy();
+    this.set('flash', FlashMessage.create({
+      message: 'flash message content',
+      sticky: true,
+      destroyOnClick: false,
+      destroyMessage
+    }));
+
+    this.render(hbs`
+      {{#flash-message flash=flash as |component flash close|}}
+        {{flash.message}}
+        <a href="#" {{action close}}>close</a>
+      {{/flash-message}}
+    `);
+
+    assert.notOk(destroyMessage.calledOnce, 'flash has not been destroyed yet');
+    this.$(":contains(flash message content)").click();
+    assert.notOk(destroyMessage.calledOnce, 'flash has not been destroyed yet');
+    this.$(":contains(close)").click();
+    assert.ok(destroyMessage.calledOnce, 'flash is destroyed after clicking close');
+  });
 }


### PR DESCRIPTION
This adds in the ability to close the flash message in your own custom components. I tweaked the example in the readme to include a close button in the template there. I've also tried this in my own app :)

If we like this idea, we should probably make a separate example that has close on click set to false (since currently this example it wouldn't quite make sense why we want the close button when you can click on the whole thing to close it).