### PR TITLE
WIP track when timer resumes

### DIFF
--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -15,6 +15,7 @@ export default EmberObject.extend(Evented, {
   exitTimer: null,
   exiting: false,
   initializedTime: null,
+  resumedTime: null,
 
   queue: readOnly('flashService.queue'),
   totalTimeout: customComputed.add('timeout', 'extendedTimeout').readOnly(),
@@ -76,6 +77,7 @@ export default EmberObject.extend(Evented, {
     if (get(this, 'sticky')) {
       return;
     }
+    set(this, 'resumedTime', new Date().getTime());
     this._setupTimers();
   },
 
@@ -97,7 +99,7 @@ export default EmberObject.extend(Evented, {
 
   _getElapsedTime() {
     let currentTime = new Date().getTime();
-    let initializedTime = get(this, 'initializedTime');
+    let initializedTime = get(this, 'resumedTime') || get(this, 'initializedTime');
 
     return currentTime - initializedTime;
   },

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -16,5 +16,11 @@ export default Ember.Route.extend({
     });
 
     flashMessages.danger('You went offline');
+
+    flashMessages.success('Good job! Ok, bye', {
+      timeout: 5000,
+      sticky: false,
+      showProgress: true
+    });
   }
 });


### PR DESCRIPTION
Closes: https://github.com/poteto/ember-cli-flash/issues/237

The remaining time was always calculating on the initial time the message appeared. This truly pauses the timer.

Gif of tracking the remaining amount of time:
![flash-hover](https://user-images.githubusercontent.com/881981/29902916-f567a012-8dce-11e7-99ac-1334497900b4.gif)
