### PR TITLE
Prevent early destruction from mouse events

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -83,14 +83,14 @@ export default Component.extend({
   mouseEnter() {
     const flash = get(this, 'flash');
     if (isPresent(flash)) {
-      flash.deferTimers();
+      flash.preventExit();
     }
   },
 
   mouseLeave() {
     const flash = get(this, 'flash');
     if (isPresent(flash)) {
-      flash.resumeTimers();
+      flash.allowExit();
     }
   },
 

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -8,7 +8,15 @@ export default Ember.Route.extend({
 
     flashMessages.success('Route transitioned successfully', {
       priority: 500,
-      showProgress: true
+      showProgress: true,
+    });
+
+    flashMessages.success('Three second timout with a two second exit', {
+      priority: 100,
+      showProgress: true,
+      sticky: false,
+      timeout: 3000,
+      extendedTimeout: 2000
     });
 
     flashMessages.warning('It is going to rain tomorrow', {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -527,3 +527,16 @@ hr {
   -webkit-transition-timing-function: linear;
   transition-timing-function: linear;
 }
+
+.alert.exiting {
+  background-image: linear-gradient(
+			-45deg,
+			rgba(255, 255, 255, .25) 25%,
+			transparent 25%,
+			transparent 50%,
+			rgba(255, 255, 255, .25) 50%,
+			rgba(255, 255, 255, .25) 75%,
+			transparent 75%
+		);
+	background-size: 30px 30px;
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -521,6 +521,7 @@ hr {
 .alert .alert-progressBar {
   background: white;
   width: 0%;
+  height: 100%;
   -webkit-transition-property: width;
   transition-property: width;
   -webkit-transition-timing-function: linear;

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -66,6 +66,7 @@ if (parseFloat(Ember.VERSION) > 2.0) {
     assert.notOk(destroyMessage.calledOnce, 'flash has not been destroyed yet');
 
     clock.tick(timeoutDefault);
+    clock.tick(timeoutDefault);
     assert.ok(destroyMessage.calledOnce, 'flash is destroyed after timeout');
 
     clock.restore();

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import Ember from 'ember';
 import FlashMessage from 'ember-cli-flash/flash/object';
-import sinon from 'sinon';
 
 const testTimerDuration = 50;
 const {
@@ -78,13 +77,6 @@ test('#destroyMessage deletes the message and timer', function(assert) {
   assert.equal(flash.get('timer'), null);
 });
 
-test('it sets an `exitTimer` when `extendedTimeout` is set', function(assert) {
-  const exitFlash = FlashMessage.create({
-    extendedTimeout: testTimerDuration
-  });
-  assert.ok(exitFlash.get('exitTimer'));
-});
-
 test('it sets `exiting` to true after the timer has elapsed', function(assert) {
   assert.expect(2);
   const done = assert.async();
@@ -96,75 +88,9 @@ test('it sets `exiting` to true after the timer has elapsed', function(assert) {
 
   run.later(() => {
     assert.equal(exitFlash.get('exiting'), true, 'it sets `exiting` to true');
-    assert.equal(exitFlash.get('exitTimer'), null, 'it cancels the `exitTimer`');
+    assert.equal(exitFlash.get('timer'), null, 'it cancels the `timer`');
     done();
   }, testTimerDuration * 2);
-});
-
-test('#deferTimers cancels timers and updates timeout', function(assert) {
-  assert.expect(2);
-
-  const getElapsedTimeStub = sinon.stub().returns(5);
-
-  const exitFlash = FlashMessage.create({
-    timeout: testTimerDuration,
-    extendedTimeout: testTimerDuration,
-    _getElapsedTime: getElapsedTimeStub
-  });
-
-  exitFlash.deferTimers();
-
-  assert.equal(exitFlash.get('timeout'), 45, 'elapsed time is subtracted from timeout');
-  assert.notOk(exitFlash.get('timer'), 'timer is canceled');
-});
-
-test('#deferTimers is not called if message is sticky', function(assert) {
-  assert.expect(2);
-
-  const getElapsedTimeStub = sinon.stub();
-  const cancelAllTimerStub = sinon.stub();
-
-  const exitFlash = FlashMessage.create({
-    sticky: true,
-    timeout: testTimerDuration,
-    extendedTimeout: testTimerDuration,
-    _getElapsedTime: getElapsedTimeStub,
-    _cancelAllTimers: cancelAllTimerStub
-  });
-
-  exitFlash.deferTimers();
-
-  assert.notOk(getElapsedTimeStub.called, 'elapsed time is not called');
-  assert.notOk(cancelAllTimerStub.called, 'cancel timers is not called');
-});
-
-test('#resumeTimers resets timers', function(assert) {
-  assert.expect(2);
-
-  const exitFlash = FlashMessage.create({
-    timeout: testTimerDuration,
-    extendedTimeout: testTimerDuration
-  });
-
-  exitFlash.resumeTimers();
-
-  assert.ok(exitFlash.get('timer'), 'timer is started');
-  assert.ok(exitFlash.get('exitTimer'), 'timer is started');
-});
-
-test('#resumeTimers resets timers', function(assert) {
-  assert.expect(1);
-
-  const setupTimerStub = sinon.stub();
-
-  const exitFlash = FlashMessage.create({
-    sticky: true,
-    _setupTimers: setupTimerStub
-  });
-
-  exitFlash.resumeTimers();
-
-  assert.notOk(setupTimerStub.called, 'setup timers is not called');
 });
 
 test('it calls `onDestroy` when object is destroyed', function(assert) {


### PR DESCRIPTION
This removes the logic around pausing and restarting timers in favor of setting a flag which prevents the exit and destroy while being moused over. A related change is to set the timeout timer to trigger `exitMessage` which in turn sets a timer of destroy based on the `extendedTimout`. This prevents having to juggle two timers separately.

In reference to Issue [237](https://github.com/poteto/ember-cli-flash/issues/237)