### PR TITLE
Use FlashObject#exitMessage on click or close

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -77,7 +77,7 @@ export default Component.extend({
     const destroyOnClick = getWithDefault(this, 'flash.destroyOnClick', true);
 
     if (destroyOnClick) {
-      this._destroyFlashMessage();
+      this._exitFlashMessage();
     }
   },
 
@@ -110,9 +110,18 @@ export default Component.extend({
     }
   },
 
+  _exitFlashMessage() {
+    const flash = getWithDefault(this, 'flash', false);
+
+    if (flash && !get(flash, 'isDestroyed')) {
+      flash.allowExit();
+      flash.exitMessage();
+    }
+  },
+
   actions: {
     close() {
-      this._destroyFlashMessage();
+      this._exitFlashMessage();
     }
   }
 });

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -99,6 +99,8 @@ test('a custom component can use the close closure action', function(assert) {
 
   this.set('flash', FlashMessage.create({
     message: 'flash message content',
+    extendedTimeout: 0,
+    timeout: 0,
     sticky: true,
     destroyOnClick: false
   }));
@@ -114,5 +116,8 @@ test('a custom component can use the close closure action', function(assert) {
   this.$(":contains(flash message content)").click();
   assert.notOk(this.get('flash').isDestroyed, 'flash has not been destroyed yet');
   this.$(":contains(close)").click();
-  assert.ok(this.get('flash').isDestroyed, 'flash is destroyed after clicking close');
+  later(() => {
+    assert.ok(this.get('flash').isDestroyed, 'flash is destroyed after clicking close');
+  }, 10);
+  return wait();
 });

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -4,12 +4,11 @@ import {
   moduleForComponent,
   test
 } from 'ember-qunit';
-import FlashMessage from 'ember-cli-flash/flash/object';
+import FlashObject from 'ember-cli-flash/flash/object';
 
 const {
   run,
-  get,
-  set
+  get
 } = Ember;
 let flash;
 
@@ -17,11 +16,11 @@ moduleForComponent('flash-message', 'FlashMessageComponent', {
   unit: true,
 
   beforeEach() {
-    flash = FlashMessage.create({
+    flash = FlashObject.create({
       message: 'test',
       type: 'test',
       timeout: 50,
-      extendedTimeout: 5000,
+      extendedTimeout: 500,
       showProgress: true
     });
   },
@@ -50,31 +49,62 @@ test('it renders with the right props', function(assert) {
 test('exiting the flash object sets exiting on the component', function(assert) {
   assert.expect(2);
 
+  const done = assert.async();
   const component = this.subject({ flash });
-  this.render();
-  assert.equal(get(component, 'exiting'), false, 'it initializes with `exiting` set to false');
 
   run(() => {
-    set(flash, 'exiting' , true);
+    this.render();
+    assert.equal(get(component, 'exiting'), false, 'it initializes with `exiting` set to false');
+    run.later(() => {
+      assert.ok(get(component, 'exiting'), 'it sets `exiting` to true when the flash object is exiting');
+      done();
+    }, 51);
+  });
+});
+
+test('exiting the flash object sets exiting when sticky & clicking to remove', function(assert) {
+  assert.expect(3);
+  flash.sticky = true;
+
+  const done = assert.async();
+  const component = this.subject({ flash });
+
+  run(() => {
+    this.render();
+    assert.equal(get(component, 'exiting'), false, 'it initializes with `exiting` set to false');
+    $('.alert').click();
     assert.ok(get(component, 'exiting'), 'it sets `exiting` to true when the flash object is exiting');
+
+    run.later(() => {
+      assert.ok(get(component, 'flash').isDestroyed, 'it destroys the flash object on click');
+      done();
+    }, 551);
   });
 });
 
 test('it destroys the flash object on click', function(assert) {
   assert.expect(1);
+  const done = assert.async();
   const component = this.subject({ flash });
   this.render();
 
   $('.alert').click();
-  assert.ok(get(component, 'flash').isDestroyed, 'it destroys the flash object on click');
+  run.later(() => {
+    assert.ok(get(component, 'flash').isDestroyed, 'it destroys the flash object on click');
+    done();
+  }, 551);
 });
 
 test('it does not destroy the flash object when `flash.destroyOnClick` is false', function(assert) {
   assert.expect(1);
   flash.destroyOnClick = false;
+  const done = assert.async();
   const component = this.subject({ flash });
   this.render();
 
   $('.alert').click();
-  assert.notOk(get(component, 'flash').isDestroyed, 'it does not destroy the flash object on click');
+  run.later(() => {
+    assert.notOk(get(component, 'flash').isDestroyed, 'it does not destroy the flash object on click');
+    done();
+  }, 25);
 });


### PR DESCRIPTION
This allows developers' animations that leverage `.exiting` class to still work when clicking to dismiss messages.