### PR TITLE
Revert "extendTimeout on sticky message (#240)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Then animate using CSS transitions, using the `.active` and `.active.exiting` cl
 }
 ```
 
+**NOTE:** Exit transitions currently are not supported for sticky messages.
+
 ### Arbitrary options
 You can also add arbitrary options to messages:
 

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -1,3 +1,4 @@
+import { on } from '@ember/object/evented';
 import { htmlSafe, classify } from '@ember/string';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
@@ -6,10 +7,8 @@ import { computed, set, get, getWithDefault } from '@ember/object';
 import layout from '../templates/components/flash-message';
 
 const {
-  and,
-  bool,
   readOnly,
-  not
+  bool
 } = computed;
 const {
   next,
@@ -23,9 +22,7 @@ export default Component.extend({
   classNames: ['flash-message'],
   classNameBindings: ['alertType', 'active', 'exiting'],
 
-  showProgress: readOnly('flash.showProgress'),
-  notExiting: not('exiting'),
-  showProgressBar: and('showProgress', 'notExiting'),
+  showProgressBar: readOnly('flash.showProgress'),
   exiting: readOnly('flash.exiting'),
   hasBlock: bool('template').readOnly(),
 
@@ -51,13 +48,12 @@ export default Component.extend({
     }
   }),
 
-  didInsertElement() {
-    this._super(...arguments);
+  _setActive: on('didInsertElement', function() {
     const pendingSet = next(this, () => {
       set(this, 'active', true);
     });
     set(this, 'pendingSet', pendingSet);
-  },
+  }),
 
   progressDuration: computed('flash.showProgress', {
     get() {
@@ -88,13 +84,13 @@ export default Component.extend({
 
   mouseLeave() {
     const flash = get(this, 'flash');
-    if (isPresent(flash) && !get(flash, 'exiting')) {
+    if (isPresent(flash)) {
       flash.allowExit();
     }
   },
 
   willDestroy() {
-    this._super(...arguments);
+    this._super();
     this._destroyFlashMessage();
     cancel(get(this, 'pendingSet'));
   },

--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -1,14 +1,17 @@
+import { readOnly } from '@ember/object/computed';
+import { cancel, later } from '@ember/runloop';
 import Evented from '@ember/object/evented';
 import EmberObject, { set, get } from '@ember/object';
 import customComputed from '../utils/computed';
-import { task, timeout } from 'ember-concurrency';
 
 export default EmberObject.extend(Evented, {
+  timer: null,
   exitTimer: null,
   exiting: false,
   isExitable: true,
   initializedTime: null,
 
+  queue: readOnly('flashService.queue'),
   _guid: customComputed.guidFor('message').readOnly(),
 
   init() {
@@ -17,31 +20,36 @@ export default EmberObject.extend(Evented, {
     if (get(this, 'sticky')) {
       return;
     }
-    set(this, 'timerTaskInstance', get(this, 'timerTask').perform());
+
+    this._setTimer('timer', 'exitMessage', get(this, 'timeout'));
     this._setInitializedTime();
   },
 
   destroyMessage() {
-    this._cancelTimer();
-    let exitTaskInstance = get(this, 'exitTaskInstance');
-    if (exitTaskInstance && exitTaskInstance.isRunning) {
-      exitTaskInstance.cancel();
-      this._teardown();
-    } else {
-      set(this, 'exitTaskInstance', get(this, 'exitTimerTask').perform());
+    const queue = get(this, 'queue');
+
+    if (queue) {
+      queue.removeObject(this);
     }
+
+    this.destroy();
+    this.trigger('didDestroyMessage');
   },
 
   exitMessage() {
     if (!get(this, 'isExitable')) {
       return;
     }
-    let exitTaskInstance = get(this, 'exitTimerTask').perform();
-    set(this, 'exitTaskInstance', exitTaskInstance);
+    this._setTimer('exitTimer', 'destroyMessage', get(this, 'extendedTimeout'));
+    this._cancelTimer('timer');
+
+    set(this, 'exiting', true);
     this.trigger('didExitMessage');
   },
 
   willDestroy() {
+    this._cancelAllTimers();
+
     const onDestroy = get(this, 'onDestroy');
 
     if (onDestroy) {
@@ -60,23 +68,11 @@ export default EmberObject.extend(Evented, {
     this._checkIfShouldExit();
   },
 
-  timerTask: task(function* () {
-    if (get(this, 'timeout')) {
-      yield timeout(get(this, 'timeout'));
-    }
-    this.exitMessage();
-    this._teardown();
-  }),
-
-  exitTimerTask: task(function* () {
-    set(this, 'exiting', true);
-    if (get(this, 'extendedTimeout')) {
-      yield timeout(get(this, 'extendedTimeout'));
-    }
-    this._teardown();
-  }),
-
   // private
+  _setTimer(name, methodName, timeout) {
+    return set(this, name, later(this, methodName, timeout));
+  },
+
   _setInitializedTime() {
     let currentTime = new Date().getTime();
 
@@ -90,27 +86,26 @@ export default EmberObject.extend(Evented, {
     return currentTime - initializedTime;
   },
 
-  _cancelTimer() {
-    let timerTaskInstance = get(this, 'timerTaskInstance');
-    if (timerTaskInstance) {
-      timerTaskInstance.cancel();
+  _cancelTimer(name) {
+    const timer = get(this, name);
+
+    if (timer) {
+      cancel(timer);
+      set(this, name, null);
     }
+  },
+
+  _cancelAllTimers() {
+    const timers = ['timer', 'exitTimer'];
+
+    timers.forEach((timer) => {
+      this._cancelTimer(timer);
+    });
   },
 
   _checkIfShouldExit() {
     if (this._getElapsedTime() >= get(this, 'timeout') && !get(this, 'sticky')) {
-      this._cancelTimer();
       this.exitMessage();
     }
-  },
-
-  _teardown() {
-    const queue = get(this, 'flashService.queue');
-    if (queue) {
-      queue.removeObject(this);
-    }
-
-    this.destroy();
-    this.trigger('didDestroyMessage');
   }
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-concurrency": "^0.8.10",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -6,25 +6,29 @@ const { timeout: defaultTimeout } = config.flashMessageDefaults;
 
 moduleForAcceptance('Acceptance | main');
 
-test('flash messages are rendered', async function(assert) {
+test('flash messages are rendered', function(assert) {
   assert.expect(7);
-  await visit('/');
+  visit('/');
 
-  assert.ok(find('.alert.alert-success'));
-  assert.equal(find('.alert.alert-success h6').text(), 'Success');
-  assert.equal(find('.alert.alert-success p').text(), 'Route transitioned successfully');
-  assert.equal(find('.alert.alert-success .alert-progressBar').attr('style'), `transition-duration: ${defaultTimeout}ms`);
+  andThen(() => {
+    assert.ok(find('.alert.alert-success'));
+    assert.equal(find('.alert.alert-success h6').text(), 'Success');
+    assert.equal(find('.alert.alert-success p').text(), 'Route transitioned successfully');
+    assert.equal(find('.alert.alert-success .alert-progressBar').attr('style'), `transition-duration: ${defaultTimeout}ms`);
 
-  assert.ok(find('.alert.alert-warning'));
-  assert.equal(find('.alert.alert-warning h6').text(), 'Warning');
-  assert.equal(find('.alert.alert-warning p').text(), 'It is going to rain tomorrow');
+    assert.ok(find('.alert.alert-warning'));
+    assert.equal(find('.alert.alert-warning h6').text(), 'Warning');
+    assert.equal(find('.alert.alert-warning p').text(), 'It is going to rain tomorrow');
+  });
 });
 
-test('high priority messages are rendered on top', async function(assert) {
+test('high priority messages are rendered on top', function(assert) {
   assert.expect(3);
-  await visit('/');
+  visit('/');
 
-  assert.ok(find('.alert'));
-  assert.equal(find('.alert h6').first().text(), 'Warning');
-  assert.equal(find('.alert p').first().text(), 'It is going to rain tomorrow');
+  andThen(() => {
+    assert.ok(find('.alert'));
+    assert.equal(find('.alert h6').first().text(), 'Warning');
+    assert.equal(find('.alert p').first().text(), 'It is going to rain tomorrow');
+  });
 });

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -7,7 +7,7 @@ export default Route.extend({
 
     flashMessages.success('Route transitioned successfully', {
       priority: 500,
-      showProgress: true
+      showProgress: true,
     });
 
     flashMessages.success('Three second timout with a two second exit', {
@@ -19,8 +19,7 @@ export default Route.extend({
     });
 
     flashMessages.warning('It is going to rain tomorrow', {
-      priority: 1000,
-      extendedTimeout: 1000
+      priority: 1000
     });
 
     flashMessages.danger('You went offline');

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -1,3 +1,4 @@
+import { later } from '@ember/runloop';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import FlashMessage from 'ember-cli-flash/flash/object';
@@ -36,9 +37,7 @@ test('it does not error when quickly removed from the DOM', function(assert) {
 
   this.set('flag', false);
 
-  return wait().then(() => {
-    assert.ok(this.get('flash').isDestroyed, 'Flash Object isDestroyed');
-  });
+  assert.ok(this.get('flash').isDestroyed, 'Flash Object isDestroyed');
 });
 
 test('flash message is removed after timeout', function(assert) {
@@ -67,13 +66,13 @@ test('flash message is removed after timeout', function(assert) {
 test('flash message is removed after timeout if mouse enters', function(assert) {
   assert.expect(3);
 
-  let flashObject = FlashMessage.create({
+  let foo = FlashMessage.create({
     message: 'hi',
     sticky: false,
     timeout: timeoutDefault
   });
 
-  this.set('flash', flashObject);
+  this.set('flash', foo);
 
   this.render(hbs`
     {{#flash-message elementId="testFlash" flash=flash as |component flash|}}
@@ -84,12 +83,13 @@ test('flash message is removed after timeout if mouse enters', function(assert) 
   assert.equal(this.$().text().trim(), 'hi');
   this.$('#testFlash').mouseenter();
 
-  assert.notOk(flashObject.isDestroyed, 'Flash Object is not destroyed');
+  assert.notOk(foo.isDestroyed, 'Flash Object is not destroyed');
   this.$('#testFlash').mouseleave();
 
-  return wait().then(() => {
-    assert.ok(flashObject.isDestroyed, 'Flash Object is destroyed');
-  });
+  later(() => {
+    assert.ok(foo.isDestroyed, 'Flash Object is destroyed');
+  }, 1001);
+  return wait();
 });
 
 test('a custom component can use the close closure action', function(assert) {
@@ -112,33 +112,5 @@ test('a custom component can use the close closure action', function(assert) {
   this.$(":contains(flash message content)").click();
   assert.notOk(this.get('flash').isDestroyed, 'flash has not been destroyed yet');
   this.$(":contains(close)").click();
-  return wait().then(() => {
-    assert.ok(this.get('flash').isDestroyed, 'flash is destroyed after clicking close');
-  });
-});
-
-test('exiting class is applied for sticky messages', function(assert) {
-  assert.expect(3);
-  let flashObject =  FlashMessage.create({
-    message: 'flash message content',
-    sticky: true,
-    extendedTimeout: 100
-  });
-
-  this.set('flash', flashObject);
-
-  this.render(hbs`
-    {{#flash-message flash=flash as |component flash|}}
-      <span>{{flash.message}}</span>
-    {{/flash-message}}
-  `);
-
-  const flashDiv = this.$('.alert:eq(0)');
-  flashDiv.click();
-  assert.ok(flashDiv.length, 'Flash message is shown');
-  assert.ok(flashDiv.hasClass('exiting'), 'exiting class is applied');
-
-  return wait().then(() => {
-    assert.ok(flashObject.isDestroyed, 'Flash Object is destroyed');
-  });
+  assert.ok(this.get('flash').isDestroyed, 'flash is destroyed after clicking close');
 });

--- a/tests/unit/components/flash-message-test.js
+++ b/tests/unit/components/flash-message-test.js
@@ -58,7 +58,6 @@ test('exiting the flash object sets exiting on the component', function(assert) 
 
 test('it destroys the flash object on click', function(assert) {
   assert.expect(1);
-  flash.set('extendedTimeout', 0);
   const component = this.subject({ flash });
   this.render();
 

--- a/tests/unit/flash/object-test.js
+++ b/tests/unit/flash/object-test.js
@@ -25,7 +25,7 @@ module('FlashMessageObject', {
 });
 
 test('it sets a timer after init', function(assert) {
-  assert.ok(flash.get('timerTaskInstance.isRunning'));
+  assert.ok(flash.get('timer'));
 });
 
 test('it destroys the message after the timer has elapsed', function(assert) {
@@ -94,7 +94,7 @@ test('it calls `onDestroy` when object is destroyed', function(assert) {
   assert.expect(1);
 
   const callbackFlash = FlashMessage.create({
-    sticky: true,
+    extendedTimeout: 1000,
     onDestroy() {
       assert.ok(true, 'onDestroy is called');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
+babel-core@^6.14.0, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -1736,7 +1736,7 @@ electron-to-chromium@^1.3.18:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.8.1:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -1756,24 +1756,6 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
 ember-cli-babel@^6.10.0:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz#81424acd1d97fb13658168121eeb2007d6edee84"
-  dependencies:
-    amd-name-resolver "0.0.7"
-    babel-plugin-debug-macros "^0.1.11"
-    babel-plugin-ember-modules-api-polyfill "^2.0.1"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.16.0"
-    babel-preset-env "^1.5.1"
-    broccoli-babel-transpiler "^6.1.2"
-    broccoli-debug "^0.6.2"
-    broccoli-funnel "^1.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^2.1.0"
-    semver "^5.4.1"
-
-ember-cli-babel@^6.6.0:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.9.2.tgz#ab9c650e1fdf229e70936d9629aba699a355ab40"
   dependencies:
     amd-name-resolver "0.0.7"
     babel-plugin-debug-macros "^0.1.11"
@@ -2077,15 +2059,6 @@ ember-cli@~2.16.2:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
-ember-concurrency@^0.8.10:
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.10.tgz#5788d1a43ed1e73562495719b29efe903c789675"
-  dependencies:
-    babel-core "^6.24.1"
-    ember-cli-babel "^6.6.0"
-    ember-getowner-polyfill "^2.0.0"
-    ember-maybe-import-regenerator "^0.1.5"
-
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
@@ -2096,33 +2069,11 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-factory-for-polyfill@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.2.0.tgz#e27752a7d9dbd5336e8b470341bc1c55bbe3e4d2"
-  dependencies:
-    ember-cli-version-checker "^1.2.0"
-
-ember-getowner-polyfill@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
-  dependencies:
-    ember-cli-version-checker "^1.2.0"
-    ember-factory-for-polyfill "^1.1.0"
-
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
-
-ember-maybe-import-regenerator@^0.1.5:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.0.0"
-    ember-cli-babel "^6.0.0-beta.4"
-    regenerator-runtime "^0.9.5"
 
 ember-qunit@^2.2.0:
   version "2.2.0"
@@ -4490,10 +4441,6 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
-
-regenerator-runtime@^0.9.5:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
This reverts commit eec395792e2941e552f93f2ab358d30bf0e40812.

This causes problems because `ember-concurrency` is not in this addon's dependecies.  I'm reverting so we can have a little more discussion about this without having 1.6 out there broken.