### PR TITLE
Add ambient TypeScript type information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,61 @@
+declare module 'ember-cli-flash/flash/object' {
+  
+  import EmberObject from '@ember/object';
+  import Evented from '@ember/object/evented';
+  
+  class FlashObject extends EmberObject.extend(Evented) {
+    exiting: boolean;
+    exitTimer: number;
+    isExitable: boolean;
+    initializedTime: number;
+    destroyMessage(): void;
+    exitMessage(): void;
+    preventExit(): void;
+    allowExit(): void;
+    timerTask(): void;
+    exitTimerTask(): void;
+  }
+  export default FlashObject;
+}
+
+declare module 'ember-cli-flash/services/flash-messages' {
+
+  import Service from '@ember/service';
+  import FlashObject from 'ember-cli-flash/flash/object';
+
+  type Partial<T> = { [K in keyof T]?: T[K] };
+
+  interface MessageOptions {
+    type: string;
+    priority: number;
+    timeout: number;
+    sticky: boolean;
+    showProgress: boolean;
+    extendedTimeout: number;
+    destroyOnClick: boolean;
+    onDestroy: () => void;
+  }
+  
+  interface CustomMessageInfo extends Partial<MessageOptions> {
+    message: string;
+  }
+  
+  interface FlashFunction {
+    (message: string, options?: Partial<MessageOptions>): FlashMessageService;
+  }
+  
+  class FlashMessageService extends Service {
+    success: FlashFunction;
+    warning: FlashFunction;
+    info: FlashFunction;
+    danger: FlashFunction;
+    alert: FlashFunction;
+    secondary: FlashFunction;
+    add(messageInfo: CustomMessageInfo): FlashMessageService;
+    clearMessages(): FlashMessageService;
+    registerTypes(types: string[]): FlashMessageService;
+    getFlashObject(): FlashObject;
+  }
+
+  export default FlashMessageService;
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "devDependencies": {
+    "@types/ember": "^2.8.4",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "~2.16.2",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,26 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
+"@types/ember@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.4.tgz#764036bfe750ca4e1f7148d7b9e396dbd959cec6"
+  dependencies:
+    "@types/handlebars" "*"
+    "@types/jquery" "*"
+    "@types/rsvp" "*"
+
+"@types/handlebars@*":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
+
+"@types/jquery@*":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.17.tgz#01df9805dd5cf83a14cf5bfd81adced7d4fbd970"
+
+"@types/rsvp@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/rsvp/-/rsvp-4.0.1.tgz#82956bc8d0a8151ec3b7e9cae64fd06808a1c714"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
Fixes #257 

Consumers will need to do the following in order to take advantage of this type information.

### Explicitly indicate the type of this service with a type annotation

##### app/components/x-foo.ts
```ts
import Component from '@ember/component';
import ComputedProperty from '@ember/object/computed';
import { inject } from '@ember/service';
import FlashService from 'ember-cli-flash/services/flash-messages';

export default class XFooComponent extends Component {
  public flashMessages: ComputedProperty<FlashService> = inject();

  public onSuccess() {
    // Type-check is happy with this!
    this.get('flashMessages').success('Success!');
  }
}

```