### PR TITLE
remove requirement for providing a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Ember.get(this, 'flashMessages').success('This is amazing', {
 
 - `message: string`
 
-  Required. The message that the flash message displays.
+  Required when `preventDuplicates` is enabled. The message that the flash message displays.
 
 - `type?: string`
 

--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -78,7 +78,8 @@ export default Service.extend({
   },
 
   _newFlashMessage(options = {}) {
-    assert('The flash message cannot be empty.', options.message);
+    assert('The flash message cannot be empty when preventDuplicates is enabled.',
+        get(this, 'defaultPreventDuplicates') ? options.message : true);
 
     const flashService = this;
     const allDefaults = getWithDefault(this, 'flashMessageDefaults', {});
@@ -141,13 +142,16 @@ export default Service.extend({
 
   _enqueue(flashInstance) {
     const preventDuplicates = get(this, 'defaultPreventDuplicates');
-    const guid = get(flashInstance, '_guid');
 
-    if (preventDuplicates && this._hasDuplicate(guid)) {
-      warn('Attempting to add a duplicate message to the Flash Messages Service', false, {
-        id: 'ember-cli-flash.duplicate-message'
-      });
-      return;
+    if (preventDuplicates) {
+      const guid = get(flashInstance, '_guid');
+
+      if (this._hasDuplicate(guid)) {
+        warn('Attempting to add a duplicate message to the Flash Messages Service', false, {
+          id: 'ember-cli-flash.duplicate-message'
+        });
+        return;
+      }
     }
 
     return get(this, 'queue').pushObject(flashInstance);

--- a/tests/unit/services/flash-messages-test.js
+++ b/tests/unit/services/flash-messages-test.js
@@ -169,7 +169,7 @@ test('when preventDuplicates is `false` setting a message is not required', func
     customProperty: 'ohai'
   });
 
-  assert.equal(get(service, 'queue.0.customProperty'), 'ohai');
+  assert.equal(get(service, 'queue.firstObject.customProperty'), 'ohai');
 });
 
 test('when preventDuplicates is `true`, setting a message is required', function(assert) {

--- a/tests/unit/services/flash-messages-test.js
+++ b/tests/unit/services/flash-messages-test.js
@@ -175,9 +175,14 @@ test('when preventDuplicates is `false` setting a message is not required', func
 test('when preventDuplicates is `true`, setting a message is required', function(assert) {
   set(service, 'defaultPreventDuplicates', true);
 
-  assert.throws((() => {
-    service.add({ });
-  }).message, 'Assertion Failed: The flash message cannot be empty when preventDuplicates is enabled.');
+  assert.throws(() => {
+      service.add({ });
+    },
+    ({ message }) => {
+      return message == 'Assertion Failed: The flash message cannot be empty when preventDuplicates is enabled.';
+    },
+    'Error is thrown'
+  );
 });
 
 test('it adds duplicate messages to the queue if preventDuplicates is `false`', function(assert) {

--- a/tests/unit/services/flash-messages-test.js
+++ b/tests/unit/services/flash-messages-test.js
@@ -162,6 +162,24 @@ test('it sets the correct defaults for service properties', function(assert) {
   }
 });
 
+test('when preventDuplicates is `false` setting a message is not required', function(assert) {
+  set(service, 'defaultPreventDuplicates', false);
+
+  service.add({
+    customProperty: 'ohai'
+  });
+
+  assert.equal(get(service, 'queue.0.customProperty'), 'ohai');
+});
+
+test('when preventDuplicates is `true`, setting a message is required', function(assert) {
+  set(service, 'defaultPreventDuplicates', true);
+
+  assert.throws((() => {
+    service.add({ });
+  }).message, 'Assertion Failed: The flash message cannot be empty when preventDuplicates is enabled.');
+});
+
 test('it adds duplicate messages to the queue if preventDuplicates is `false`', function(assert) {
   set(service, 'defaultPreventDuplicates', false);
   const expectedResult = emberArray([ 'foo', 'foo', 'bar' ]);


### PR DESCRIPTION
fixes #259 

I figured it would be reasonable to keep the `message` property required when `preventDuplicates` is enabled as that feature relies on the message string.

Please let me know or feel free to modify the added test, if you know of any better way to assert a thrown error than that:
```
assert.throws((() => {
  service.add({ });
}).message, 'Assertion Failed: The flash message cannot be empty when preventDuplicates is enabled.');
```