### PR TITLE
update blueprint to handle newer test-helper.js

### DIFF
--- a/blueprints/ember-cli-flash/index.js
+++ b/blueprints/ember-cli-flash/index.js
@@ -1,4 +1,5 @@
 var EOL = require('os').EOL;
+let VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   description: 'Generates ember-cli-flash test helper',
@@ -6,11 +7,20 @@ module.exports = {
   afterInstall: function() {
     var TEST_HELPER_PATH = 'tests/test-helper.js';
     var IMPORT_STATEMENT = EOL + "import './helpers/flash-message';";
-    var INSERT_AFTER = "import resolver from './helpers/resolver';";
+    var INSERT_AFTER_PRE_2_17 = "import resolver from './helpers/resolver';";
+    var INSERT_AFTER_POST_2_17 = "import { start } from 'ember-qunit';";
 
-    return this.insertIntoFile(TEST_HELPER_PATH, IMPORT_STATEMENT, {
-      after: INSERT_AFTER
-    });
+    let checker = new VersionChecker(this);
+    let ember = checker.forEmber();
+
+    let after;
+    if (ember.isAbove('2.17.0')) {
+      after = INSERT_AFTER_POST_2_17;
+    } else {
+      after = INSERT_AFTER_PRE_2_17;
+    }
+
+    return this.insertIntoFile(TEST_HELPER_PATH, IMPORT_STATEMENT, { after });
   },
 
   normalizeEntityName: function() {}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",


### PR DESCRIPTION
On newer Ember versions, test-helper.js does not include an `import { resolver }` line anymore. Instead, we insert after the last line in the default `test-helper.js`, the qunit import.

This should support [any version >= 2.17](https://github.com/ember-cli/ember-new-output/blame/v2.17.0/tests/test-helper.js#L3), which hopefully is good enough.

Fixes #262.