### PR TITLE
remove deprecated usage of Ember.copy

### DIFF
--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -1,6 +1,4 @@
-import { merge } from '@ember/polyfills';
 import Service from '@ember/service';
-import { copy } from '@ember/object/internals';
 import { typeOf, isNone } from '@ember/utils';
 import { warn, assert } from '@ember/debug';
 import {
@@ -89,7 +87,7 @@ export default Service.extend({
       'preventDuplicates'
     ]);
 
-    const flashMessageOptions = merge(copy(defaults), { flashService });
+    const flashMessageOptions = Object.assign({}, defaults, { flashService });
 
     for (let key in options) {
       const value = get(options, key);
@@ -129,7 +127,7 @@ export default Service.extend({
     assert('The flash type cannot be undefined', type);
 
     this[type] = ((message, options = {}) => {
-      const flashMessageOptions = copy(options);
+      const flashMessageOptions = Object.assign({}, options);
       setProperties(flashMessageOptions, { message, type });
 
       return this.add(flashMessageOptions);


### PR DESCRIPTION
Fixes #173. Fixes deprecations in Ember v3.3.