### PR TITLE
provide default config/overrides to FlashMessageService w/o injections

### DIFF
--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -5,7 +5,8 @@ import {
   set,
   get,
   setProperties,
-  getWithDefault
+  getWithDefault,
+  computed
 } from '@ember/object';
 import {
   mapBy,
@@ -17,6 +18,8 @@ import { assign } from '@ember/polyfills';
 import { A as emberArray } from '@ember/array';
 import FlashMessage from 'ember-cli-flash/flash/object';
 import objectWithout from '../utils/object-without';
+import { getOwner } from '@ember/application';
+import flashMessageOptions from '../utils/flash-message-options';
 
 export default Service.extend({
   isEmpty: equal('queue.length', 0).readOnly(),
@@ -110,6 +113,12 @@ export default Service.extend({
 
     return value;
   },
+
+  flashMessageDefaults: computed(function() {
+    const config  = getOwner(this).resolveRegistration('config:environment');
+    const overrides = getWithDefault(config, 'flashMessageDefaults', {});
+    return flashMessageOptions(overrides);
+  }),
 
   _setDefaults() {
     const defaults = getWithDefault(this, 'flashMessageDefaults', {});

--- a/addon/utils/flash-message-options.js
+++ b/addon/utils/flash-message-options.js
@@ -1,0 +1,31 @@
+/* eslint-disable ember/new-module-imports */
+import Ember from 'ember';
+const merge = Ember.merge || Ember.assign;
+
+export default function(configOverrides) {
+  const addonDefaults = {
+    timeout: 3000,
+    extendedTimeout: 0,
+    priority: 100,
+    sticky: false,
+    showProgress: false,
+    type: 'info',
+    types: [
+      'success',
+      'info',
+      'warning',
+      'danger',
+      'alert',
+      'secondary'
+    ],
+    injectionFactories: [
+      'route',
+      'controller',
+      'view',
+      'component'
+    ],
+    preventDuplicates: false
+  };
+  return merge(addonDefaults, configOverrides);
+}
+

--- a/app/initializers/flash-messages.js
+++ b/app/initializers/flash-messages.js
@@ -2,41 +2,15 @@ import Ember from 'ember';
 import config from '../config/environment';
 /* eslint-disable ember/new-module-imports */
 const { deprecate } = Ember;
-const merge = Ember.assign || Ember.merge;
 const INJECTION_FACTORIES_DEPRECATION_MESSAGE = '[ember-cli-flash] Future versions of ember-cli-flash will no longer inject the service automatically. Instead, you should explicitly inject it into your Route, Controller or Component with `Ember.inject.service`.';
-const addonDefaults = {
-  timeout: 3000,
-  extendedTimeout: 0,
-  priority: 100,
-  sticky: false,
-  showProgress: false,
-  type: 'info',
-  types: [
-    'success',
-    'info',
-    'warning',
-    'danger',
-    'alert',
-    'secondary'
-  ],
-  injectionFactories: [
-    'route',
-    'controller',
-    'view',
-    'component'
-  ],
-  preventDuplicates: false
-};
+import flashMessageOptions from 'ember-cli-flash/utils/flash-message-options';
 
 export function initialize() {
   const application = arguments[1] || arguments[0];
   const { flashMessageDefaults } = config || {};
   const { injectionFactories } = flashMessageDefaults || [];
-  const options = merge(addonDefaults, flashMessageDefaults);
+  const options = flashMessageOptions(flashMessageDefaults);
   const shouldShowDeprecation = !(injectionFactories && injectionFactories.length);
-
-  application.register('config:flash-messages', options, { instantiate: false });
-  application.inject('service:flash-messages', 'flashMessageDefaults', 'config:flash-messages');
 
   deprecate(INJECTION_FACTORIES_DEPRECATION_MESSAGE, shouldShowDeprecation, {
     id: 'ember-cli-flash.deprecate-injection-factories',

--- a/tests/unit/services/flash-messages-test.js
+++ b/tests/unit/services/flash-messages-test.js
@@ -4,20 +4,22 @@ import { set, get } from '@ember/object';
 import { classify } from '@ember/string';
 import { A as emberArray } from '@ember/array';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 import config from '../../../config/environment';
-import FlashMessagesService from 'ember-cli-flash/services/flash-messages';
+import FlashMessagesService from 'dummy/services/flash-messages';
 import EmberError from '@ember/error';
 
 let service;
 let SANDBOX = {};
 
-module('FlashMessagesService', {
-  beforeEach() {
-    const { flashMessageDefaults } = config;
-    service = FlashMessagesService.create({ flashMessageDefaults });
-  },
+module('FlashMessagesService', function(hooks) {
+  setupTest(hooks);
 
-  afterEach() {
+  hooks.beforeEach(function() {
+    service = FlashMessagesService.create(this.owner.ownerInjection());
+  });
+
+  hooks.afterEach(function() {
     run(() => {
       get(service, 'queue').clear();
       service.destroy();
@@ -25,216 +27,216 @@ module('FlashMessagesService', {
 
     service = null;
     SANDBOX = {};
-  }
-});
-
-test('#queue returns an array of flash messages', function(assert) {
-  assert.expect(2);
-
-  service.success('success 1');
-  service.success('success 2');
-  service.success('success 3');
-
-  assert.equal(typeOf(get(service, 'queue')), 'array', 'it returns an array');
-  assert.equal(get(service, 'queue.length'), 3, 'it returns the correct number of flash messages');
-});
-
-test('#arrangedQueue returns an array of flash messages, sorted by priority', function(assert) {
-  assert.expect(4);
-
-  service.success('success 1', { priority: 100 });
-  service.success('success 2', { priority: 200 });
-  service.success('success 3', { priority: 300 });
-
-  assert.equal(typeOf(get(service, 'queue')), 'array', 'it returns an array');
-  assert.equal(get(service, 'queue.length'), 3, 'it returns the correct number of flash messages');
-  assert.equal(get(service, 'arrangedQueue.0.priority'), 300, 'it returns flash messages in the right order');
-  assert.equal(get(service, 'arrangedQueue.2.priority'), 100, 'it returns flash messages in the right order');
-});
-
-test('#arrangedQueue is read only', function(assert) {
-  assert.expect(2);
-
-  assert.throws(() => {
-    service.set('arrangedQueue', [ 'foo' ]);
   });
 
-  assert.equal(get(service, 'arrangedQueue.length'), 0, 'it did not set #arrangedQueue');
-});
+  test('#queue returns an array of flash messages', function(assert) {
+    assert.expect(2);
 
-test('#add adds a custom message', function(assert) {
-  assert.expect(4);
+    service.success('success 1');
+    service.success('success 2');
+    service.success('success 3');
 
-  service.add({
-    message: 'test',
-    type: 'test',
-    timeout: 1,
-    sticky: true,
-    showProgress: true
+    assert.equal(typeOf(get(service, 'queue')), 'array', 'it returns an array');
+    assert.equal(get(service, 'queue.length'), 3, 'it returns the correct number of flash messages');
   });
 
-  assert.equal(get(service, 'queue.0.type'), 'test', 'it has the correct type');
-  assert.equal(get(service, 'queue.0.timeout'), 1, 'it has the correct timeout');
-  assert.equal(get(service, 'queue.0.sticky'), true, 'it has the correct sticky');
-  assert.equal(get(service, 'queue.0.showProgress'), true, 'it has the correct show progress');
-});
+  test('#arrangedQueue returns an array of flash messages, sorted by priority', function(assert) {
+    assert.expect(4);
 
-test('#add adds a custom message with default type', function(assert) {
-  assert.expect(1);
+    service.success('success 1', { priority: 100 });
+    service.success('success 2', { priority: 200 });
+    service.success('success 3', { priority: 300 });
 
-  SANDBOX.flash = service.add({
-    message: 'test'
+    assert.equal(typeOf(get(service, 'queue')), 'array', 'it returns an array');
+    assert.equal(get(service, 'queue.length'), 3, 'it returns the correct number of flash messages');
+    assert.equal(get(service, 'arrangedQueue.0.priority'), 300, 'it returns flash messages in the right order');
+    assert.equal(get(service, 'arrangedQueue.2.priority'), 100, 'it returns flash messages in the right order');
   });
 
-  assert.equal(get(service, 'queue.0.type'), 'info', 'it has the correct type');
-});
+  test('#arrangedQueue is read only', function(assert) {
+    assert.expect(2);
 
-test('#clearMessages clears the queue', function(assert) {
-  assert.expect(2);
+    assert.throws(() => {
+      service.set('arrangedQueue', [ 'foo' ]);
+    });
 
-  service.success('foo');
-  service.success('bar');
-  service.success('baz');
-  service.clearMessages();
-
-  assert.equal(typeOf(get(service, 'queue')), 'array', 'it returns an array');
-  assert.equal(get(service, 'queue.length'), 0, 'it clears the array');
-});
-
-test('#registerTypes registers new types', function(assert) {
-  assert.expect(2);
-
-  service.registerTypes(['foo', 'bar']);
-  SANDBOX.type1 = service.foo;
-  SANDBOX.type2 = service.bar;
-
-  assert.equal(typeOf(SANDBOX.type1), 'function', 'it creates a new method on the service');
-  assert.equal(typeOf(SANDBOX.type2), 'function', 'it creates a new method on the service');
-});
-
-test('it registers default types on init', function(assert) {
-  const defaultTypes = [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ];
-  const expectLength = defaultTypes.length * 2;
-
-  assert.expect(expectLength);
-
-  defaultTypes.forEach((type) => {
-    const method = service[type];
-
-    assert.ok(method);
-    assert.equal(typeOf(method), 'function');
-  });
-});
-
-test('it adds specific options via add()', function(assert) {
-  assert.expect(1);
-
-  service.add({
-    message: "here's an option you may or may not know",
-    appOption: 'ohai'
+    assert.equal(get(service, 'arrangedQueue.length'), 0, 'it did not set #arrangedQueue');
   });
 
-  assert.equal(get(service, 'queue.0.appOption'), 'ohai');
-});
+  test('#add adds a custom message', function(assert) {
+    assert.expect(4);
 
-test('it adds specific options via specific message type', function(assert) {
-  assert.expect(1);
+    service.add({
+      message: 'test',
+      type: 'test',
+      timeout: 1,
+      sticky: true,
+      showProgress: true
+    });
 
-  service.info('you can pass app options this way too', {
-    appOption: 'we meet again app-option'
+    assert.equal(get(service, 'queue.0.type'), 'test', 'it has the correct type');
+    assert.equal(get(service, 'queue.0.timeout'), 1, 'it has the correct timeout');
+    assert.equal(get(service, 'queue.0.sticky'), true, 'it has the correct sticky');
+    assert.equal(get(service, 'queue.0.showProgress'), true, 'it has the correct show progress');
   });
 
-  assert.equal(get(service, 'queue.0.appOption'), 'we meet again app-option');
-});
+  test('#add adds a custom message with default type', function(assert) {
+    assert.expect(1);
 
-test('it sets the correct defaults for service properties', function(assert) {
-  const { flashMessageDefaults } = config;
-  const configOptions = Object.keys(flashMessageDefaults);
-  const expectLength = configOptions.length;
+    SANDBOX.flash = service.add({
+      message: 'test'
+    });
 
-  assert.expect(expectLength);
-
-  for (let option in flashMessageDefaults) {
-    const classifiedKey = `default${classify(option)}`;
-    const defaultValue = service[classifiedKey];
-    const configValue = flashMessageDefaults[option];
-
-    assert.equal(defaultValue, configValue);
-  }
-});
-
-test('when preventDuplicates is `false` setting a message is not required', function(assert) {
-  set(service, 'defaultPreventDuplicates', false);
-
-  service.add({
-    customProperty: 'ohai'
+    assert.equal(get(service, 'queue.0.type'), 'info', 'it has the correct type');
   });
 
-  assert.equal(get(service, 'queue.firstObject.customProperty'), 'ohai');
-});
+  test('#clearMessages clears the queue', function(assert) {
+    assert.expect(2);
 
-test('when preventDuplicates is `true`, setting a message is required', function(assert) {
-  set(service, 'defaultPreventDuplicates', true);
+    service.success('foo');
+    service.success('bar');
+    service.success('baz');
+    service.clearMessages();
 
-  assert.throws(() => {
-      service.add({ });
-    },
-    new EmberError('Assertion Failed: The flash message cannot be empty when preventDuplicates is enabled.'),
-    'Error is thrown'
-  );
-});
+    assert.equal(typeOf(get(service, 'queue')), 'array', 'it returns an array');
+    assert.equal(get(service, 'queue.length'), 0, 'it clears the array');
+  });
 
-test('it adds duplicate messages to the queue if preventDuplicates is `false`', function(assert) {
-  set(service, 'defaultPreventDuplicates', false);
-  const expectedResult = emberArray([ 'foo', 'foo', 'bar' ]);
-  expectedResult.forEach((message) => service.success(message));
-  const result = get(service, 'queue').mapBy('message');
+  test('#registerTypes registers new types', function(assert) {
+    assert.expect(2);
 
-  assert.deepEqual(result, expectedResult, 'it adds duplicate messages to the queue');
-  assert.equal(get(service, 'queue').length, 3, 'it adds duplicate messages to the queue');
-});
+    service.registerTypes(['foo', 'bar']);
+    SANDBOX.type1 = service.foo;
+    SANDBOX.type2 = service.bar;
 
-test('it does not add duplicate messages to the queue if preventDuplicates is `true`', function(assert) {
-  set(service, 'defaultPreventDuplicates', true);
-  const messages = emberArray([ 'foo', 'foo', 'bar' ]);
-  const expectedResult = messages.uniq();
-  messages.forEach((message) => service.success(message));
-  const result = get(service, 'queue').mapBy('message');
+    assert.equal(typeOf(SANDBOX.type1), 'function', 'it creates a new method on the service');
+    assert.equal(typeOf(SANDBOX.type2), 'function', 'it creates a new method on the service');
+  });
 
-  assert.deepEqual(result, expectedResult, 'it does not add duplicate messages to the queue');
-  assert.equal(get(service, 'queue').length, 2, 'it does not add duplicate messages to the queue');
-});
+  test('it registers default types on init', function(assert) {
+    const defaultTypes = [ 'success', 'info', 'warning', 'danger', 'alert', 'secondary' ];
+    const expectLength = defaultTypes.length * 2;
 
-test('it supports chaining', function(assert) {
-  service
-    .registerTypes(['meow'])
-    .clearMessages()
-    .add({ message: 'foo' })
-    .meow('bar');
+    assert.expect(expectLength);
 
-  assert.equal(get(service, 'queue.firstObject.message'), 'foo', 'should support chaining');
-  assert.equal(get(service, 'queue.lastObject.message'), 'bar', 'should support chaining');
-});
+    defaultTypes.forEach((type) => {
+      const method = service[type];
 
-test('it returns flash object when fetched through `getFlashObject`', function(assert) {
-  const { flashMessageDefaults } = config;
-  const flash = service
-    .clearMessages()
-    .add({ message: 'foo' })
-    .getFlashObject();
+      assert.ok(method);
+      assert.equal(typeOf(method), 'function');
+    });
+  });
 
-  assert.equal(get(flash, 'message'), 'foo', 'it returns flash object with correct message');
-  assert.equal(get(flash, 'timeout'), flashMessageDefaults.timeout, 'it returns an object with defaults');
-});
+  test('it adds specific options via add()', function(assert) {
+    assert.expect(1);
 
-test('it supports public API methods for `peekLast` and `peekFirst`', function(assert) {
-  service.clearMessages();
+    service.add({
+      message: "here's an option you may or may not know",
+      appOption: 'ohai'
+    });
 
-  assert.equal(typeOf(service.peekLast()), 'undefined', 'returns undefined when queue is empty');
-  assert.equal(typeOf(service.peekFirst()), 'undefined', 'returns undefined when queue is empty');
+    assert.equal(get(service, 'queue.0.appOption'), 'ohai');
+  });
 
-  service.add({ message: 'foo' }).add({ message: 'bar' });
+  test('it adds specific options via specific message type', function(assert) {
+    assert.expect(1);
 
-  assert.equal(service.peekFirst().message, 'foo', 'returns first object from queue');
-  assert.equal(service.peekLast().message, 'bar', 'returns last object from queue');
+    service.info('you can pass app options this way too', {
+      appOption: 'we meet again app-option'
+    });
+
+    assert.equal(get(service, 'queue.0.appOption'), 'we meet again app-option');
+  });
+
+  test('it sets the correct defaults for service properties', function(assert) {
+    const { flashMessageDefaults } = config;
+    const configOptions = Object.keys(flashMessageDefaults);
+    const expectLength = configOptions.length;
+
+    assert.expect(expectLength);
+
+    for (let option in flashMessageDefaults) {
+      const classifiedKey = `default${classify(option)}`;
+      const defaultValue = service[classifiedKey];
+      const configValue = flashMessageDefaults[option];
+
+      assert.equal(defaultValue, configValue);
+    }
+  });
+
+  test('when preventDuplicates is `false` setting a message is not required', function(assert) {
+    set(service, 'defaultPreventDuplicates', false);
+
+    service.add({
+      customProperty: 'ohai'
+    });
+
+    assert.equal(get(service, 'queue.firstObject.customProperty'), 'ohai');
+  });
+
+  test('when preventDuplicates is `true`, setting a message is required', function(assert) {
+    set(service, 'defaultPreventDuplicates', true);
+
+    assert.throws(() => {
+        service.add({ });
+      },
+      new EmberError('Assertion Failed: The flash message cannot be empty when preventDuplicates is enabled.'),
+      'Error is thrown'
+    );
+  });
+
+  test('it adds duplicate messages to the queue if preventDuplicates is `false`', function(assert) {
+    set(service, 'defaultPreventDuplicates', false);
+    const expectedResult = emberArray([ 'foo', 'foo', 'bar' ]);
+    expectedResult.forEach((message) => service.success(message));
+    const result = get(service, 'queue').mapBy('message');
+
+    assert.deepEqual(result, expectedResult, 'it adds duplicate messages to the queue');
+    assert.equal(get(service, 'queue').length, 3, 'it adds duplicate messages to the queue');
+  });
+
+  test('it does not add duplicate messages to the queue if preventDuplicates is `true`', function(assert) {
+    set(service, 'defaultPreventDuplicates', true);
+    const messages = emberArray([ 'foo', 'foo', 'bar' ]);
+    const expectedResult = messages.uniq();
+    messages.forEach((message) => service.success(message));
+    const result = get(service, 'queue').mapBy('message');
+
+    assert.deepEqual(result, expectedResult, 'it does not add duplicate messages to the queue');
+    assert.equal(get(service, 'queue').length, 2, 'it does not add duplicate messages to the queue');
+  });
+
+  test('it supports chaining', function(assert) {
+    service
+      .registerTypes(['meow'])
+      .clearMessages()
+      .add({ message: 'foo' })
+      .meow('bar');
+
+    assert.equal(get(service, 'queue.firstObject.message'), 'foo', 'should support chaining');
+    assert.equal(get(service, 'queue.lastObject.message'), 'bar', 'should support chaining');
+  });
+
+  test('it returns flash object when fetched through `getFlashObject`', function(assert) {
+    const { flashMessageDefaults } = config;
+    const flash = service
+      .clearMessages()
+      .add({ message: 'foo' })
+      .getFlashObject();
+
+    assert.equal(get(flash, 'message'), 'foo', 'it returns flash object with correct message');
+    assert.equal(get(flash, 'timeout'), flashMessageDefaults.timeout, 'it returns an object with defaults');
+  });
+
+  test('it supports public API methods for `peekLast` and `peekFirst`', function(assert) {
+    service.clearMessages();
+
+    assert.equal(typeOf(service.peekLast()), 'undefined', 'returns undefined when queue is empty');
+    assert.equal(typeOf(service.peekFirst()), 'undefined', 'returns undefined when queue is empty');
+
+    service.add({ message: 'foo' }).add({ message: 'bar' });
+
+    assert.equal(service.peekFirst().message, 'foo', 'returns first object from queue');
+    assert.equal(service.peekLast().message, 'bar', 'returns last object from queue');
+  });
 });


### PR DESCRIPTION
While I was writing a component integration test in my app, I noticed
that I couldn't call `this.flashMessages.success` or any of the built in
convenience functions that target the bootstrap notifications.

This seems to be because, unless an application test runs first, the
service isn't getting set up with the right config. It looks like the
service is expecting it from only the initializer right now.

I changed app/services/flash-message.js to import the config from the
application, so that it is always set up correctly regardless of the
test context.

I also extracted the logic for merging the addon defaults and the app
overrides into a utility module so we could use the same logic in both
places as much as possible.

The unit test was updated to use the flash message service from the app instead (and not manually import the config). That was the best way I could think of to test it.