### PR TITLE
Avoid deprecation warning about Ember.merge

### DIFF
--- a/addon/utils/flash-message-options.js
+++ b/addon/utils/flash-message-options.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/new-module-imports */
 import Ember from 'ember';
-const merge = Ember.merge || Ember.assign;
+const assign = Ember.assign || Ember.merge;
 
 export default function(configOverrides) {
   const addonDefaults = {
@@ -26,6 +26,6 @@ export default function(configOverrides) {
     ],
     preventDuplicates: false
   };
-  return merge(addonDefaults, configOverrides);
+  return assign(addonDefaults, configOverrides);
 }
 


### PR DESCRIPTION
This PR avoids deprecation warnings about `Ember.merge` by swapping order in the `||`.

Inspired by https://github.com/simplabs/ember-simple-auth/pull/941/files

Thanks for building this thing!