### PR TITLE
Fix guidFor import

### DIFF
--- a/addon/flash/object.js
+++ b/addon/flash/object.js
@@ -1,7 +1,7 @@
 import Evented from '@ember/object/evented';
 import EmberObject, { set, get } from '@ember/object';
 import { cancel, later } from '@ember/runloop';
-import customComputed from '../utils/computed';
+import { guidFor } from '../utils/computed';
 
 export default EmberObject.extend(Evented, {
   exitTimer: null,
@@ -9,7 +9,7 @@ export default EmberObject.extend(Evented, {
   isExitable: true,
   initializedTime: null,
 
-  _guid: customComputed.guidFor('message').readOnly(),
+  _guid: guidFor('message').readOnly(),
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
its fixes #298 

```js
// this works
import { guidFor } from '../utils/computed';
guidFor(whatever);

// and this works
import * as customComputed from '../utils/computed';
customComputed.guidFor(whatever);

// but this does not work.
import customComputed from '../utils/computed';
customComputed.guidFor(whatever);
```

This is a case where ember-cli historically allows a non-spec-compliant behavior.

cc: @Dhaulagiri 