### PR TITLE
CHORE: Updates node version support from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/poteto/ember-cli-flash/issues",
   "homepage": "https://github.com/poteto/ember-cli-flash",
   "engines": {
-    "node": "^4.5 || 6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "contributors": [
     {


### PR DESCRIPTION
Should be a major release since node support below 8 is dropped. Might as well be tagged as under 2.x beta channel?