### PR TITLE
Fix `getWithDefault` deprecation warning

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -2,8 +2,9 @@ import { htmlSafe, classify } from '@ember/string';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
 import { run } from '@ember/runloop';
-import { computed, set, get, getWithDefault } from '@ember/object';
+import { computed, set, get } from '@ember/object';
 import layout from '../templates/components/flash-message';
+import getWithDefault from '../utils/get-with-default';
 
 const {
   and,

--- a/addon/services/flash-messages.js
+++ b/addon/services/flash-messages.js
@@ -5,7 +5,6 @@ import {
   set,
   get,
   setProperties,
-  getWithDefault,
   computed
 } from '@ember/object';
 import {
@@ -20,6 +19,7 @@ import FlashMessage from 'ember-cli-flash/flash/object';
 import objectWithout from '../utils/object-without';
 import { getOwner } from '@ember/application';
 import flashMessageOptions from '../utils/flash-message-options';
+import getWithDefault from '../utils/get-with-default';
 
 export default Service.extend({
   isEmpty: equal('queue.length', 0).readOnly(),

--- a/addon/utils/get-with-default.js
+++ b/addon/utils/get-with-default.js
@@ -1,0 +1,11 @@
+import { get } from '@ember/object';
+
+export default function getWithDefault(objectInstance, key, defaultValue) {
+  let value = get(objectInstance, key);
+
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  return value;
+}

--- a/addon/utils/get-with-default.js
+++ b/addon/utils/get-with-default.js
@@ -1,9 +1,12 @@
 import { get } from '@ember/object';
 
+// This replicates Ember's deprecated `getWithDefault`.
+// Note that, as in the original, `null` is considered a valid value and will
+// not cause the function to return the default value.
 export default function getWithDefault(objectInstance, key, defaultValue) {
   let value = get(objectInstance, key);
 
-  if (value === undefined || value === null) {
+  if (value === undefined) {
     return defaultValue;
   }
 

--- a/tests/unit/utils/get-with-default-test.js
+++ b/tests/unit/utils/get-with-default-test.js
@@ -13,17 +13,6 @@ module('Unit | Utility | get-with-default', function() {
     assert.equal(result, defaultValue);
   });
 
-  test('it returns the default value when the target value is null', function(assert) {
-    let obj = {
-      testKey: null
-    }
-
-    let defaultValue = 'defaultValue';
-    let result = getWithDefault(obj, 'testKey', defaultValue);
-
-    assert.equal(result, defaultValue);
-  });
-
   test('it returns the target value when available', function(assert) {
     let obj = {
       truthy: true,
@@ -31,7 +20,8 @@ module('Unit | Utility | get-with-default', function() {
       truthyNumber: 1,
       falsyNumber: 0,
       string: 'test',
-      emptyString: ''
+      emptyString: '',
+      null: null
     }
 
     let defaultValue = 'defaultValue';

--- a/tests/unit/utils/get-with-default-test.js
+++ b/tests/unit/utils/get-with-default-test.js
@@ -1,0 +1,45 @@
+import getWithDefault from 'ember-cli-flash/utils/get-with-default';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | get-with-default', function() {
+  test('it returns the default value when the target value is undefined', function(assert) {
+    let obj = {
+      testKey: undefined
+    }
+
+    let defaultValue = 'defaultValue';
+    let result = getWithDefault(obj, 'testKey', defaultValue);
+
+    assert.equal(result, defaultValue);
+  });
+
+  test('it returns the default value when the target value is null', function(assert) {
+    let obj = {
+      testKey: null
+    }
+
+    let defaultValue = 'defaultValue';
+    let result = getWithDefault(obj, 'testKey', defaultValue);
+
+    assert.equal(result, defaultValue);
+  });
+
+  test('it returns the target value when available', function(assert) {
+    let obj = {
+      truthy: true,
+      falsy: false,
+      truthyNumber: 1,
+      falsyNumber: 0,
+      string: 'test',
+      emptyString: ''
+    }
+
+    let defaultValue = 'defaultValue';
+
+    for (let [key, value] of Object.entries(obj)) {
+      let result = getWithDefault(obj, key, defaultValue);
+
+      assert.equal(result, value);
+    }
+  });
+});


### PR DESCRIPTION
Starting with Ember v3.21, `getWithDefault` is deprecated and will be removed in v4.0.

https://emberjs.github.io/rfcs/0554-deprecate-getwithdefault.html

This PR adds the function as a utility, complete with tests.

I intentionally avoided the nullish operator `??` as it isn't available, based on the project's eslint config.
I did, however, add an explicit check for `null`. [Ember's default implementation does not do this](https://github.com/emberjs/ember.js/blob/93fb76515ec4b808962ea68ae95b11ead6986681/packages/%40ember/-internals/metal/lib/property_get.ts#L180), but it seems appropriate to add given the issues brought up in the RFC and provides a direct upgrade path to using `??` without `get`. I've checked all the usages of `getWithDefault` and believe this change shouldn't cause any unexpected issues.

