### PR TITLE
feat: added messageStylePrefix variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,15 @@ By default, flash messages will have Bootstrap style class names. If you want to
 {{/each}}
 ```
 
+### Styling with user-specified flash type class prefix
+If you don't wish to use the class names associated with Bootstrap / Foundation, specify the `flashTypePrefix` on the component. This will override the class name prefixes with your own. For example, `flashTypePrefix='special-alert-'` would create flash messages with the class `special-alert-succcess`
+
+```handlebars
+{{#each flashMessages.queue as |flash|}}
+  {{flash-message flash=flash flashTypePrefix='special-alert-'}}
+{{/each}}
+```
+
 ### Sort messages by priority
 To display messages sorted by priority, add this to your template:
 

--- a/README.md
+++ b/README.md
@@ -377,12 +377,12 @@ By default, flash messages will have Bootstrap style class names. If you want to
 {{/each}}
 ```
 
-### Styling with user-specified flash type class prefix
-If you don't wish to use the class names associated with Bootstrap / Foundation, specify the `flashTypePrefix` on the component. This will override the class name prefixes with your own. For example, `flashTypePrefix='special-alert-'` would create flash messages with the class `special-alert-succcess`
+### Styling with user-specified message type class prefix
+If you don't wish to use the class names associated with Bootstrap / Foundation, specify the `messageStylePrefix` on the component. This will override the class name prefixes with your own. For example, `messageStylePrefix='special-alert-'` would create flash messages with the class `special-alert-succcess`
 
 ```handlebars
 {{#each flashMessages.queue as |flash|}}
-  {{flash-message flash=flash flashTypePrefix='special-alert-'}}
+  {{flash-message flash=flash messageStylePrefix='special-alert-'}}
 {{/each}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ If you don't wish to use the class names associated with Bootstrap / Foundation,
 
 ```handlebars
 {{#each flashMessages.queue as |flash|}}
-  {{flash-message flash=flash messageStylePrefix='special-alert-'}}
+  <FlashMessage @flash={{flash}} @messageStylePrefix='special-alert-' />
 {{/each}}
 ```
 

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -1,7 +1,8 @@
-import { htmlSafe, classify } from '@ember/string';
 import Component from '@ember/component';
+import { htmlSafe, classify } from '@ember/string';
 import { isPresent } from '@ember/utils';
 import { run } from '@ember/runloop';
+import { assert } from '@ember/debug'
 import { action, computed, set } from '@ember/object';
 import { and, bool, readOnly, not } from '@ember/object/computed';
 import { tagName } from '@ember-decorators/component';
@@ -30,20 +31,18 @@ export default class FlashMessage extends Component {
   @bool('template')
   hasBlock;
 
-  @computed('messageStyle')
-  get messageStylePrefix() {
+  @computed('messageStyle', 'messageStylePrefix')
+  get _defaultMessageStylePrefix() {
+    assert('messageStyle is not used when messageStylePrefix is defined', this.messageStyle && this.messageStylePrefix)
     const isFoundation = this.messageStyle === 'foundation';
     return isFoundation ? 'alert-box ' : 'alert alert-';
   }
 
-  @computed('flash.type', 'flashTypePrefix', 'messageStylePrefix')
+  @computed('flash.type', 'messageStylePrefix', '_defaultMessageStylePrefix')
   get alertType() {
     const flashType = this.flash.type || '';
-
-    const { flashTypePrefix, messageStylePrefix } = this;
-
-    const prefix = flashTypePrefix ? flashTypePrefix : messageStylePrefix;
-    return `${prefix || ''}${flashType}`;
+    const prefix = this.messageStylePrefix || this._defaultMessageStylePrefix || '';
+    return `${prefix}${flashType}`;
   }
 
   @computed('flash.type')

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -29,7 +29,7 @@ export default class FlashMessage extends Component {
   @bool('template')
   hasBlock;
 
-  @computed('messageStyle', 'messageStylePrefix')
+  @computed('messageStyle')
   get _defaultMessageStylePrefix() {
     const isFoundation = this.messageStyle === 'foundation';
     return isFoundation ? 'alert-box ' : 'alert alert-';

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { htmlSafe, classify } from '@ember/string';
 import { isPresent } from '@ember/utils';
 import { run } from '@ember/runloop';
-import { assert } from '@ember/debug'
 import { action, computed, set } from '@ember/object';
 import { and, bool, readOnly, not } from '@ember/object/computed';
 import layout from '../templates/components/flash-message';
@@ -32,7 +31,6 @@ export default class FlashMessage extends Component {
 
   @computed('messageStyle', 'messageStylePrefix')
   get _defaultMessageStylePrefix() {
-    assert('messageStyle is not used when messageStylePrefix is defined', this.messageStyle && this.messageStylePrefix)
     const isFoundation = this.messageStyle === 'foundation';
     return isFoundation ? 'alert-box ' : 'alert alert-';
   }

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -30,23 +30,20 @@ export default class FlashMessage extends Component {
   @bool('template')
   hasBlock;
 
-  @computed('flash.type', 'flashTypePrefix', 'messageStyle')
+  @computed('messageStyle')
+  get messageStylePrefix() {
+    const isFoundation = this.messageStyle === 'foundation';
+    return isFoundation ? 'alert-box ' : 'alert alert-';
+  }
+
+  @computed('flash.type', 'flashTypePrefix', 'messageStylePrefix')
   get alertType() {
     const flashType = this.flash.type || '';
-    const flashTypePrefix = this.flashTypePrefix;
 
-    if (flashTypePrefix) {
-      return `${flashTypePrefix}${flashType}`;
-    } else {
-      const messageStyle = this.messageStyle || '';
-      let prefix = 'alert alert-';
+    const { flashTypePrefix, messageStylePrefix } = this;
 
-      if (messageStyle === 'foundation') {
-        prefix = 'alert-box ';
-      }
-
-      return `${prefix}${flashType}`;
-    }
+    const prefix = flashTypePrefix ? flashTypePrefix : messageStylePrefix;
+    return `${prefix || ''}${flashType}`;
   }
 
   @computed('flash.type')

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -30,17 +30,23 @@ export default class FlashMessage extends Component {
   @bool('template')
   hasBlock;
 
-  @computed('flash.type', 'messageStyle')
+  @computed('flash.type', 'flashTypePrefix', 'messageStyle')
   get alertType() {
     const flashType = this.flash.type || '';
-    const messageStyle = this.messageStyle || '';
-    let prefix = 'alert alert-';
+    const flashTypePrefix = this.flashTypePrefix;
 
-    if (messageStyle === 'foundation') {
-      prefix = 'alert-box ';
+    if (flashTypePrefix) {
+      return `${flashTypePrefix}${flashType}`;
+    } else {
+      const messageStyle = this.messageStyle || '';
+      let prefix = 'alert alert-';
+
+      if (messageStyle === 'foundation') {
+        prefix = 'alert-box ';
+      }
+
+      return `${prefix}${flashType}`;
     }
-
-    return `${prefix}${flashType}`;
   }
 
   @computed('flash.type')

--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -38,7 +38,7 @@ export default class FlashMessage extends Component {
   @computed('flash.type', 'messageStylePrefix', '_defaultMessageStylePrefix')
   get alertType() {
     const flashType = this.flash.type || '';
-    const prefix = this.messageStylePrefix || this._defaultMessageStylePrefix || '';
+    const prefix = this.messageStylePrefix || this._defaultMessageStylePrefix;
     return `${prefix}${flashType}`;
   }
 

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -217,7 +217,7 @@ module('Integration | Component | flash message', function (hooks) {
     assert.ok(flashObject.isDestroyed, 'Flash Object is destroyed');
   });
 
-  test('custom flash type class name prefix is applied', async function (assert) {
+  test('custom message type class name prefix is applied', async function (assert) {
     assert.expect(2);
     let flashObject = FlashMessage.create({
       message: 'flash message content',
@@ -226,10 +226,10 @@ module('Integration | Component | flash message', function (hooks) {
     });
 
     this.set('flash', flashObject);
-    this.set('flashTypePrefix', 'my-flash-')
+    this.set('messageStylePrefix', 'my-flash-')
 
     await render(hbs`
-      <FlashMessage @flash={{this.flash}} @flashTypePrefix={{this.flashTypePrefix}} as |component flash|>
+      <FlashMessage @flash={{this.flash}} @messageStylePrefix={{this.messageStylePrefix}} as |component flash|>
         <span>{{flash.message}}</span>
       </FlashMessage>
     `);

--- a/tests/integration/components/flash-message-test.js
+++ b/tests/integration/components/flash-message-test.js
@@ -216,4 +216,25 @@ module('Integration | Component | flash message', function (hooks) {
     assert.dom('.alert').hasClass('exiting', 'exiting class is applied');
     assert.ok(flashObject.isDestroyed, 'Flash Object is destroyed');
   });
+
+  test('custom flash type class name prefix is applied', async function (assert) {
+    assert.expect(2);
+    let flashObject = FlashMessage.create({
+      message: 'flash message content',
+      type: 'test',
+      sticky: true,
+    });
+
+    this.set('flash', flashObject);
+    this.set('flashTypePrefix', 'my-flash-')
+
+    await render(hbs`
+      <FlashMessage @flash={{this.flash}} @flashTypePrefix={{this.flashTypePrefix}} as |component flash|>
+        <span>{{flash.message}}</span>
+      </FlashMessage>
+    `);
+
+    assert.dom('.my-flash-test').exists({ count: 1 }, 'it uses the provided flash type class name prefix')
+    assert.dom('.my-flash-test').doesNotHaveClass('alert', 'default flash type class name is not present')
+  })
 });


### PR DESCRIPTION
Enable the ability to not use the generic bootstrap or foundation class names, by adding ~~`flashTypePrefix`~~`messageStylePrefix` which provides a way for the user to specify the flash type class name prefix.

Backwards compatibility is maintained with `messageStyle`, but if ~~`flashTypePrefix`~~`messageStylePrefix` is set it will take priority.

```hbs
{{#each flashMessages.queue as |flash|}}
  <FlashMessage @flash={{this.flash}} @messageStylePrefix="special-alert-" />
{{/each}}
```
would produce an element like
```html
<div class="flash-message special-alert-success" > ... </div>
```

#### Rationale
I've been running a custom flash-message component for this addon for a while now, because;
* the flash-message component in this addon was a bit old
* the classes `alert` and `alert-box` are very overused and poorly scoped in our 15-20 frontend apps... we really needed to avoid using these class names, and this addon didn't provide a way to customize that (without resorting to a custom component)

I noticed that with v2.0.0 the component has been updated to be tagless, render modifiers etc so I thought I would contribute some of my workings back to the project, with the aim of being able to use the component in this addon again!