### PR TITLE
feat: improved a11y for flash message component by default

### DIFF
--- a/addon/templates/components/flash-message.hbs
+++ b/addon/templates/components/flash-message.hbs
@@ -1,5 +1,6 @@
 <div
   class="flash-message {{this.alertType}} {{if this.exiting "exiting"}} {{if this.active "active"}}"
+  role="alert"
   ...attributes
   {{on "click" this.onClick}}
   {{did-insert this.onDidInsert}}


### PR DESCRIPTION
Just noticed this while working on https://github.com/poteto/ember-cli-flash/pull/335

I _think_ `role="alert"` is what we want. There's also `role="alertdialog"` but I think that's more for when there is a decision to be made in a dialog context (eg yes/no/cancel)