### PR TITLE
docs(README): fix text about the tests helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ When you install the addon, it should automatically generate a helper located at
 $ ember generate ember-cli-flash
 ```
 
-This also adds the helper to `tests/test-helper.js`. You won't actually need to import this into your tests, but it's good to know what the blueprint does. Basically, the helper overrides the `_setInitialState` method so that the flash messages behave intuitively in a testing environment.
+This also adds the helper to `tests/test-helper.js`. You won't actually need to import this into your tests, but it's good to know what the blueprint does. Basically, the helper overrides a method used to initialise the flash-message's class, so that it behaves intuitively in a testing environment.
 
 Some example tests below, based on qunit.
 


### PR DESCRIPTION
The previous private method mentioned, `_setInitialState`, [was deleted years ago](https://github.com/poteto/ember-cli-flash/commit/8f528df052614349f706090ec38320f97332b741#diff-7849ff4eea465d4b3a6358619e5da44fa1163e0ec092460b8c2694539d417394).