### PR TITLE
Update htmlSafe imports

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
-import { htmlSafe, classify } from '@ember/string';
+import { classify } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { isPresent } from '@ember/utils';
 import { run } from '@ember/runloop';
 import { action, computed, set } from '@ember/object';

--- a/tests/unit/utils/computed-test.js
+++ b/tests/unit/utils/computed-test.js
@@ -1,4 +1,4 @@
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import EmberObject from '@ember/object';
 import computed from 'ember-cli-flash/utils/computed';
 import { module, test } from 'qunit';


### PR DESCRIPTION
Importing from `@ember/string` is deprecated as of Ember 3.25