### PR TITLE
refactor: delete extraneous `Partial` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,8 +23,6 @@ declare module 'ember-cli-flash/services/flash-messages' {
   import Service from '@ember/service';
   import FlashObject from 'ember-cli-flash/flash/object';
 
-  type Partial<T> = { [K in keyof T]?: T[K] };
-
   interface MessageOptions {
     type: string;
     priority: number;


### PR DESCRIPTION
TypeScript already includes a `Partial` type since its version 2.1:
https://github.com/microsoft/TypeScript-Website/blob/56c62eeb0bdbacc14d19d7428e8a2b39922922e6/packages/documentation/copy/en/release-notes/TypeScript%202.1.md#partial-readonly-record-and-pick

The deleted code still matches the current implementation:
https://github.com/microsoft/TypeScript/blob/5053b0b987295296108598bdfd87865d9751f237/lib/lib.es5.d.ts#L1468-L1473