### PR TITLE
Fix `this-property-fallback` deprecation warnings

### DIFF
--- a/addon/templates/components/flash-message.hbs
+++ b/addon/templates/components/flash-message.hbs
@@ -7,7 +7,7 @@
   {{will-destroy this.onWillDestroy}}
 >
   {{#if hasBlock}}
-    {{yield this flash (action "onClose")}}
+    {{yield this this.flash (action "onClose")}}
   {{else}}
     {{this.flash.message}}
     {{#if this.showProgressBar}}


### PR DESCRIPTION
This MR fixes https://github.com/poteto/ember-cli-flash/issues/354