### PR TITLE
Fix missing modifier error in consuming apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     }
   ],
   "dependencies": {
+    "@ember/render-modifiers": "^1.0.2",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-htmlbars": "^4.2.3",
     "ember-runtime-enumerable-includes-polyfill": "^2.1.0"
@@ -37,7 +38,6 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@ember/optional-features": "^1.3.0",
-    "@ember/render-modifiers": "^1.0.2",
     "@types/ember": "^3.1.1",
     "babel-eslint": "^8.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
To be included in an app, `@ember/render-modifiers` needs to be a dependency of this addon, not just a dev dependency.

Fixes #357.