### PR TITLE
Change hasBlock to has-block to avoid deprecation

### DIFF
--- a/addon/components/flash-message.js
+++ b/addon/components/flash-message.js
@@ -4,7 +4,7 @@ import { htmlSafe } from '@ember/template';
 import { isPresent } from '@ember/utils';
 import { run } from '@ember/runloop';
 import { action, computed, set } from '@ember/object';
-import { and, bool, readOnly, not } from '@ember/object/computed';
+import { and, readOnly, not } from '@ember/object/computed';
 import layout from '../templates/components/flash-message';
 
 const { next, cancel } = run;
@@ -26,9 +26,6 @@ export default class FlashMessage extends Component {
 
   @readOnly('flash.exiting')
   exiting;
-
-  @bool('template')
-  hasBlock;
 
   @computed('messageStyle')
   get _defaultMessageStylePrefix() {

--- a/addon/templates/components/flash-message.hbs
+++ b/addon/templates/components/flash-message.hbs
@@ -6,7 +6,7 @@
   {{did-insert this.onDidInsert}}
   {{will-destroy this.onWillDestroy}}
 >
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield this this.flash (action "onClose")}}
   {{else}}
     {{this.flash.message}}


### PR DESCRIPTION
I'm getting this error in one of my apps:

```
DEPRECATION: `hasBlock` is deprecated. Use `has-block` instead. ('ember-cli-flash/templates/components/flash-message.hbs' @ L9:C8)  [deprecation id: has-block-and-has-block-params] See https://deprecations.emberjs.com/v3.x#toc_has-block-and-has-block-params for more details.
        at logDeprecationStackTrace (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:1984:21)
        at HANDLERS.<computed> (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:2117:9)
        at raiseOnDeprecation (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:2011:9)
        at HANDLERS.<computed> (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:2117:9)
        at invoke (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:2129:9)
        at deprecate (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:2085:28)
        at emitDeprecationMessage (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:19966:49)
        at PathExpression (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:19982:13)
        at visitNode (/Users/peterwagenet/Development/Tilde/events-app/node_modules/ember-source/dist/ember-template-compiler.js:11855:16)
```

I'm hoping that this will help work around it.