### PR TITLE
fix: import deprecate from @ember/debug

### DIFF
--- a/app/initializers/flash-messages.js
+++ b/app/initializers/flash-messages.js
@@ -1,5 +1,5 @@
 import config from '../config/environment';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 
 /* eslint-disable ember/new-module-imports */
 const INJECTION_FACTORIES_DEPRECATION_MESSAGE = '[ember-cli-flash] Future versions of ember-cli-flash will no longer inject the service automatically. Instead, you should explicitly inject it into your Route, Controller or Component with `Ember.inject.service`.';


### PR DESCRIPTION
Same issue than the one on https://github.com/emberjs/ember-test-helpers/pull/1066, in canary `import { deprecate } from '@ember/application/deprecations'` don't work anymore, replaced it by `import { deprecate } from '@ember/debug';`

When running test on ember-canary scenario, it is failing (job timeout) with this error
```
Global error: Uncaught Error: Could not find module `@ember/application/deprecations` imported from `dummy/initializers/flash-messages`
```