### PR TITLE
import deprecate from '@ember/debug'

### DIFF
--- a/app/initializers/flash-messages.js
+++ b/app/initializers/flash-messages.js
@@ -1,5 +1,5 @@
 import config from '../config/environment';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 
 /* eslint-disable ember/new-module-imports */
 const INJECTION_FACTORIES_DEPRECATION_MESSAGE = '[ember-cli-flash] Future versions of ember-cli-flash will no longer inject the service automatically. Instead, you should explicitly inject it into your Route, Controller or Component with `Ember.inject.service`.';


### PR DESCRIPTION
following [this deprecation](https://deprecations.emberjs.com/v3.x#toc_old-deprecate-method-paths)