### PR TITLE
fix: allow custom `on*` properties and make `removeBy()` immediate

### DIFF
--- a/src/flash/object.ts
+++ b/src/flash/object.ts
@@ -35,6 +35,18 @@ export type FlashObjectOptions<
   onDidExitMessage?: () => void;
 } & T;
 
+const INTERNAL_KEYS = new Set([
+  // Lifecycle callbacks — already assigned to `this` above the loop, but
+  // listed here as a safety net in case future refactors change that order.
+  'onDestroy',
+  'onDidDestroyMessage',
+  'onDidExitMessage',
+  // Options consumed by the constructor but not stored as class properties.
+  'testHelperDisableTimeout',
+  // Stored in a private field (#flashService), so `key in this` won't catch it.
+  'flashService',
+]);
+
 export default class FlashObject<
   T extends Record<string, unknown> = Record<string, unknown>,
 > {
@@ -99,7 +111,7 @@ export default class FlashObject<
 
     // Copy any custom properties from T
     for (const [key, value] of Object.entries(options)) {
-      if (!(key in this) && key !== 'flashService' && !key.startsWith('on')) {
+      if (!(key in this) && !INTERNAL_KEYS.has(key)) {
         (this as Record<string, unknown>)[key] = value;
       }
     }

--- a/src/services/flash-messages.ts
+++ b/src/services/flash-messages.ts
@@ -214,6 +214,11 @@ export default class FlashMessagesService<
   ): boolean {
     const message = this.findBy(key, value);
     if (message) {
+      // Remove from queue immediately so the message disappears from the UI
+      // without waiting for the extendedTimeout exit-animation delay.
+      // destroyMessage() still handles timer cleanup and destroyable teardown.
+      this.queue = this.queue.filter((flash) => flash !== message);
+      this.#guidSet.delete(message._guid);
       message.destroyMessage();
       return true;
     }

--- a/tests/unit/services/flash-messages-test.ts
+++ b/tests/unit/services/flash-messages-test.ts
@@ -567,6 +567,30 @@ module('Unit | Service | flash-messages', function (hooks) {
     assert.strictEqual(service.queue.length, 0, 'it removes the message');
   });
 
+  test('#removeBy immediately removes from queue even with extendedTimeout', function (assert) {
+    const service = this.owner.lookup(
+      'service:flash-messages',
+    ) as FlashMessagesService<{ id: string }>;
+
+    service.add({
+      message: 'system-notification',
+      id: 'test-notification',
+      sticky: true,
+      extendedTimeout: 5000,
+    });
+
+    assert.strictEqual(service.queue.length, 1, 'message is in queue');
+
+    const removed = service.removeBy('id', 'test-notification');
+
+    assert.true(removed, 'removeBy returns true');
+    assert.strictEqual(
+      service.queue.length,
+      0,
+      'message is immediately removed from queue without waiting for extendedTimeout',
+    );
+  });
+
   test('it supports custom fields via generics', function (assert) {
     const service = this.owner.lookup(
       'service:flash-messages',


### PR DESCRIPTION
## Problem

1. **Custom `on*` properties silently dropped** — `FlashObject`'s constructor filtered out all keys starting with `"on"` to protect internal callbacks, but this also blocked user-defined properties like `onAction`.

2. **`removeBy()` delayed removal** — `removeBy()` delegated to `destroyMessage()`, which defers queue removal by `extendedTimeout` ms. The message stayed visible in the UI instead of disappearing immediately.

## Fix

1. Replaced the broad `!key.startsWith('on')` check with an explicit `INTERNAL_KEYS` Set containing only the five keys that must be excluded (`onDestroy`, `onDidDestroyMessage`, `onDidExitMessage`, `testHelperDisableTimeout`, `flashService`).

2. `removeBy()` now removes from queue and guid set synchronously *before* calling `destroyMessage()`. The existing `#teardown()` filter is a no-op if the item is already gone.